### PR TITLE
Update link to scenic new in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Scenic is primarily aimed at fixed screen connected devices (IoT), but can also 
 
 ## Getting Started
 
-See the [documentation for the scenic.new](https://github.com/boydm/scenic_new_archives) mix task.
+See the [documentation for the scenic.new](https://github.com/boydm/scenic_new) mix task.
 
 ## Goals
 (Not necessarily in order)


### PR DESCRIPTION
I think this is the correct link. Although perhaps the scenic_new_archives project exists but is set to private.