### PR TITLE
Remove calls to IO.puts in text_input.ex

### DIFF
--- a/lib/scenic/component/input/text_field.ex
+++ b/lib/scenic/component/input/text_field.ex
@@ -555,13 +555,11 @@ defmodule Scenic.Component.Input.TextField do
 
   # --------------------------------------------------------
   def handle_input({:key, {"enter", :press, _}}, _context, state) do
-    IO.puts("enter")
     {:noreply, state}
   end
 
   # --------------------------------------------------------
   def handle_input({:key, {"escape", :press, _}}, _context, state) do
-    IO.puts("escape")
     {:noreply, state}
   end
 


### PR DESCRIPTION
As of now, there is an `IO.puts` call whenever the enter or escape keys are pressed inside a text_field that simply prints `enter` or `escape`.

Relevant lines here: https://github.com/boydm/scenic/blob/master/lib/scenic/component/input/text_field.ex#L557-L566

This logging is unnecessary from what I can see as both of those callbacks do nothing else, this PR will remove those unneeded puts.

If this logging is necessary, is IO.puts the right way to log things to the user (considering `Logger` is already a module being used in the project)?

EDIT: bad wording, oops