### PR TITLE
ubuntu xenial (16.04) do not have libglew2.0

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -34,8 +34,8 @@ Once these components have been installed, you should be able to build the
 The easiest way to install on Ubuntu is to use apt-get. Just run the following:
 
 ```bash
-apt-get update
-apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
+sudo apt-get update
+sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew-dev
 ```
 
 Once these components have been installed, you should be able to build the


### PR DESCRIPTION

## Description

It is better to ignore specific version of libglew and instead
install libglew-dev, which will take care of the specific version.
The changes works for me on Ubuntu Xenial (16.04) and should (hopefully)
work on later Ubuntu as well.

## Motivation and Context

Enhance documentation for most popular Ubuntu LTS release.

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)
- [x] Documentation enhancements.

## Checklist

- [ ] Check other PRs and make sure that the changes are not done yet.
- [ ] The PR title is no longer than 64 characters.
