### PR TITLE
Fix Broken Scene Structure Link

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -186,6 +186,6 @@ Scenic.SensorPubSub service.
 
 ## What to read next?
 
-Next, you should read about the [structure of a scene](scene_structure.html).
+Next, you should read about the [structure of a scene](scene_structure.md).
 This will explain the parts of a scene, how to send and receive messages and how
 to push the graph to the ViewPort.


### PR DESCRIPTION

## Description

In the Getting Started, the `scene_structure` link was broken. It was linked to a file with an HTML extension, I changed to Markdown.

## Motivation and Context

Lots of new eyes on this cool project. Docs should work!

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
