### PR TITLE
Fix link

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -198,6 +198,6 @@ Scenic.SensorPubSub service.
 
 ## What to read next?
 
-Next, you should read about the [structure of a scene](scene_structure.md).
+Next, you should read about the [structure of a scene](scene_structure.html).
 This will explain the parts of a scene, how to send and receive messages and how
 to push the graph to the ViewPort.


### PR DESCRIPTION
@boydm do not take any changes that replace `.html` to `.md` under `guides` folder. A lot of the folks that do not understand how ex_doc works think that it should be changed to `.md` so that way Github links the files together.