### PR TITLE
Address first batch of credo issues found in #53

### DIFF
--- a/lib/mix/tasks/hash.ex
+++ b/lib/mix/tasks/hash.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file Credo.Check.Warning.IoInspect
 defmodule Mix.Tasks.Scenic.Hash do
   use Mix.Task
 

--- a/lib/scenic/cache.ex
+++ b/lib/scenic/cache.ex
@@ -77,7 +77,7 @@ defmodule Scenic.Cache do
     :ets.lookup_element(@cache_table, key, 3)
   rescue
     ArgumentError ->
-      raise Error, message: "Key #{inspect(key)} not found."
+      reraise(Error, [message: "Key #{inspect(key)} not found."], __STACKTRACE__)
 
     other ->
       reraise(other, __STACKTRACE__)

--- a/lib/scenic/math/matrix_utils.ex
+++ b/lib/scenic/math/matrix_utils.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 #
 #  Copyright © 2017 Boyd Multerer. All rights reserved.
 #

--- a/lib/scenic/primitive/transform/pin.ex
+++ b/lib/scenic/primitive/transform/pin.ex
@@ -10,23 +10,12 @@ defmodule Scenic.Primitive.Transform.Pin do
   # data verification and serialization
 
   # --------------------------------------------------------
-  def info(data),
-    do: """
-      #{IO.ANSI.red()}#{__MODULE__} data must be a 2d vector: {x,y}
-      #{IO.ANSI.yellow()}Received: #{inspect(data)}
-      #{IO.ANSI.default_color()}
-    """
+  defdelegate info(data), to: Scenic.Primitive.Transform.Translate  
 
   # --------------------------------------------------------
-  def verify(percent) do
-    normalize(percent)
-    true
-  rescue
-    _ -> false
-  end
+  defdelegate verify(percent), to: Scenic.Primitive.Transform.Translate
 
   # --------------------------------------------------------
   # normalize named stipples
-  @spec normalize({number(), number()}) :: {number(), number()}
-  def normalize({x, y}) when is_number(x) and is_number(y), do: {x, y}
+  defdelegate normalize(v2), to: Scenic.Primitive.Transform.Translate
 end

--- a/lib/scenic/primitive/transform/pin.ex
+++ b/lib/scenic/primitive/transform/pin.ex
@@ -10,7 +10,7 @@ defmodule Scenic.Primitive.Transform.Pin do
   # data verification and serialization
 
   # --------------------------------------------------------
-  defdelegate info(data), to: Scenic.Primitive.Transform.Translate  
+  defdelegate info(data), to: Scenic.Primitive.Transform.Translate
 
   # --------------------------------------------------------
   defdelegate verify(percent), to: Scenic.Primitive.Transform.Translate

--- a/lib/scenic/view_port/input.ex
+++ b/lib/scenic/view_port/input.ex
@@ -196,8 +196,7 @@ defmodule Scenic.ViewPort.Input do
          context,
          %{max_depth: max_depth} = state
        ) do
-    {uid, id, point} =
-      find_by_captured_point(global_pos, context, max_depth)
+    {uid, id, point} = find_by_captured_point(global_pos, context, max_depth)
 
     Scene.cast(
       context.graph_key,

--- a/lib/scenic/view_port/input.ex
+++ b/lib/scenic/view_port/input.ex
@@ -198,7 +198,6 @@ defmodule Scenic.ViewPort.Input do
        ) do
     {uid, id, point} =
       find_by_captured_point(global_pos, context, max_depth)
-      |> IO.inspect()
 
     Scene.cast(
       context.graph_key,


### PR DESCRIPTION
## Description

This PR fixes the first handful of issues from credo--namely, some warnings and design complaints (credo's terminology, not mine).

This was done mostly by turning off some of the more obnoxious errors, while occasionally laying hands on code to either delegate (to remove duplication), remove debug spam, or tweak exception handling.

All changes were run through the test suite and came back green, but we don't have 100% coverage so that's of questionable worth. I tried to stick with changes that by inspection should be correct.

## Motivation and Context

This fixes partially fixes #53 , since Credo out-of-the-box is super persnickety. If we like the work I did here, I'm happy to finish clearing out the credo complaints (currently ~ 206) so we can start from a cleanish slate going forward.

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

Elaboration on the breaking change: I removed some console spam in the viewport input code. It's a breaking change because that output won't be there if you're looking for it--shouldn't harm anything else though.

## Checklist

- [ x ] Check other PRs and make sure that the changes are not done yet.
- [ x ] The PR title is no longer than 64 characters.
