### PR TITLE
Fixing typespec for Scenic.Primitives.scene_ref

### DIFF
--- a/lib/scenic/primitives.ex
+++ b/lib/scenic/primitives.ex
@@ -639,7 +639,7 @@ defmodule Scenic.Primitives do
           ref ::
             {:graph, reference, any}
             | {module :: atom, init_data :: any}
-            | scene_name :: atom,
+            | (scene_name :: atom),
           options :: list
         ) :: Graph.t() | Primitive.t()
 


### PR DESCRIPTION
## Description

In Elixir 1.8.0-dev on macOS (installed via `brew install`), this compilation error is raised, due to an invalid typespec:

```
warning: invalid type annotation. When using the | operator to represent the union of types, make sure to wrap type annotations in parentheses: {:graph, reference, any} | {module :: atom, init_data :: any} | scene_name :: atom
  lib/scenic/primitives.ex:637


== Compilation error in file lib/scenic/primitives.ex ==
** (CompileError) lib/scenic/primitives.ex:637: type scene_name/0 undefined
    (elixir) lib/kernel/typespec.ex:815: Kernel.Typespec.compile_error/2
    (elixir) lib/kernel/typespec.ex:759: Kernel.Typespec.typespec/4
    (elixir) lib/enum.ex:1430: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (elixir) lib/enum.ex:1430: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (elixir) lib/kernel/typespec.ex:399: Kernel.Typespec.typespec/4
    (elixir) lib/kernel/typespec.ex:613: Kernel.Typespec.typespec/4
    (elixir) lib/kernel/typespec.ex:582: Kernel.Typespec.typespec/4
    (elixir) lib/enum.ex:1430: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```

## Motivation and Context

Fixes compilation error on upcoming versions of Elixir.

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
