### PR TITLE
Fix credo code readability complaints

### DIFF
--- a/lib/scenic/cache/file.ex
+++ b/lib/scenic/cache/file.ex
@@ -3,9 +3,10 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-# simple functions to load a file, following the hashing rules
-
 defmodule Scenic.Cache.File do
+  @moduledoc """
+  Simple functions to load a file, following the hashing rules  
+  """
   alias Scenic.Cache
   alias Scenic.Cache.Hash
 

--- a/lib/scenic/cache/hash.ex
+++ b/lib/scenic/cache/hash.ex
@@ -3,9 +3,10 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-# simple functions to load a file, following the hashing rules
-
 defmodule Scenic.Cache.Hash do
+  @moduledoc """
+  Ssimple functions to load a file, following the hashing rules
+  """
   #  import IEx
 
   @hash_types [:sha, :sha224, :sha256, :sha384, :sha512, :ripemd160]
@@ -13,6 +14,8 @@ defmodule Scenic.Cache.Hash do
 
   # ===========================================================================
   defmodule Error do
+    @moduledoc false
+
     defexception message: "Hash check failed"
   end
 

--- a/lib/scenic/cache/supervisor.ex
+++ b/lib/scenic/cache/supervisor.ex
@@ -2,16 +2,14 @@
 #  Created by Boyd Multerer on November 29, 2017.
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
-#  You can absolutely run the Scenic.Cache genserver directly from your own
-#  supervisor and skip this one if you want. However, if you want to hook in
-#  to callbacks on put/claim/release, then you need to start up this
-#  supervisor, which manages both the cache and the callback registry.
-#
-#  The various Scenic rendering engines do use the callbacks for texture
-#  and font management, so you are probably best off using this supervisor...
 
 defmodule Scenic.Cache.Supervisor do
-  @moduledoc false
+  @moduledoc """
+  The various Scenic rendering engines do use the callbacks for texture and font management, so you are probably best off using this supervisor...
+
+  You can absolutely run the Scenic.Cache genserver directly from your own supervisor and skip this one if you want.
+  However, if you want to hook in to callbacks on put/claim/release, then you need to start up this supervisor, which manages both the cache and the callback registry. 
+  """
   use Supervisor
   alias Scenic.Cache
 

--- a/lib/scenic/cache/term.ex
+++ b/lib/scenic/cache/term.ex
@@ -3,9 +3,11 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-# simple functions to load a file, following the hashing rules
-
 defmodule Scenic.Cache.Term do
+  @moduledoc """
+  Simple functions to load a file, following the hashing rules.
+  """
+
   alias Scenic.Cache
   alias Scenic.Cache.Hash
 

--- a/lib/scenic/component.ex
+++ b/lib/scenic/component.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Component do
+  @moduledoc false
+
   alias Scenic.Primitive
 
   @callback add_to_graph(map, any, list) :: map
@@ -14,6 +16,8 @@ defmodule Scenic.Component do
 
   # ===========================================================================
   defmodule Error do
+    @moduledoc false
+
     defexception message: nil, error: nil, data: nil
   end
 

--- a/lib/scenic/component/button.ex
+++ b/lib/scenic/component/button.ex
@@ -1,4 +1,6 @@
 defmodule Scenic.Component.Button do
+  @moduledoc false
+
   use Scenic.Component, has_children: false
 
   alias Scenic.Graph

--- a/lib/scenic/component/input/caret.ex
+++ b/lib/scenic/component/input/caret.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Component.Input.Caret do
+  @moduledoc false
+
   use Scenic.Component, has_children: false
 
   import Scenic.Primitives,

--- a/lib/scenic/component/input/checkbox.ex
+++ b/lib/scenic/component/input/checkbox.ex
@@ -1,4 +1,6 @@
 defmodule Scenic.Component.Input.Checkbox do
+  @moduledoc false
+
   use Scenic.Component, has_children: false
 
   alias Scenic.Graph

--- a/lib/scenic/component/input/dropdown.ex
+++ b/lib/scenic/component/input/dropdown.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Component.Input.Dropdown do
+  @moduledoc false
+
   use Scenic.Component, has_children: false
 
   alias Scenic.Graph

--- a/lib/scenic/component/input/radio_button.ex
+++ b/lib/scenic/component/input/radio_button.ex
@@ -1,4 +1,6 @@
 defmodule Scenic.Component.Input.RadioButton do
+  @moduledoc false
+
   use Scenic.Component, has_children: false
 
   alias Scenic.Graph

--- a/lib/scenic/component/input/radio_group.ex
+++ b/lib/scenic/component/input/radio_group.ex
@@ -1,4 +1,5 @@
 defmodule Scenic.Component.Input.RadioGroup do
+  @moduledoc false
   use Scenic.Component, has_children: true
 
   alias Scenic.Graph

--- a/lib/scenic/component/input/slider.ex
+++ b/lib/scenic/component/input/slider.ex
@@ -1,4 +1,6 @@
 defmodule Scenic.Component.Input.Slider do
+  @moduledoc false
+
   use Scenic.Component, has_children: false
 
   alias Scenic.Graph

--- a/lib/scenic/component/input/text_field.ex
+++ b/lib/scenic/component/input/text_field.ex
@@ -4,6 +4,7 @@
 #
 
 defmodule Scenic.Component.Input.TextField do
+  @moduledoc false
   use Scenic.Component, has_children: true
 
   alias Scenic.Graph

--- a/lib/scenic/graph.ex
+++ b/lib/scenic/graph.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Graph do
+  @moduledoc false
+
   alias Scenic.Primitive
   alias Scenic.Primitive.Group
 

--- a/lib/scenic/math/quad.ex
+++ b/lib/scenic/math/quad.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Math.Quad do
+  @moduledoc false
+
   alias Scenic.Math
 
   @type classification ::

--- a/lib/scenic/primitive.ex
+++ b/lib/scenic/primitive.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive do
+  @moduledoc false
+
   alias Scenic.Graph
   alias Scenic.Primitive
   alias Scenic.Primitive.Style
@@ -60,6 +62,8 @@ defmodule Scenic.Primitive do
 
   # ===========================================================================
   defmodule Error do
+    @moduledoc false
+
     defexception message: nil, error: nil, data: nil
   end
 

--- a/lib/scenic/primitive/arc.ex
+++ b/lib/scenic/primitive/arc.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Arc do
+  @moduledoc false
+
   use Scenic.Primitive
   alias Scenic.Primitive.Sector
   alias Scenic.Primitive.Triangle

--- a/lib/scenic/primitive/circle.ex
+++ b/lib/scenic/primitive/circle.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Circle do
+  @moduledoc false
+
   use Scenic.Primitive
 
   @styles [:hidden, :fill, :stroke]

--- a/lib/scenic/primitive/ellipse.ex
+++ b/lib/scenic/primitive/ellipse.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Ellipse do
+  @moduledoc false
+
   use Scenic.Primitive
 
   @styles [:hidden, :fill, :stroke]

--- a/lib/scenic/primitive/group.ex
+++ b/lib/scenic/primitive/group.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Group do
+  @moduledoc false
+
   use Scenic.Primitive
   alias Scenic.Primitive
 

--- a/lib/scenic/primitive/line.ex
+++ b/lib/scenic/primitive/line.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Line do
+  @moduledoc false
+
   use Scenic.Primitive
 
   #  import IEx

--- a/lib/scenic/primitive/path.ex
+++ b/lib/scenic/primitive/path.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Path do
+  @moduledoc false
+
   use Scenic.Primitive
 
   #  import IEx

--- a/lib/scenic/primitive/quad.ex
+++ b/lib/scenic/primitive/quad.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Quad do
+  @moduledoc false
+
   use Scenic.Primitive
   alias Scenic.Math
   alias Scenic.Primitive.Triangle

--- a/lib/scenic/primitive/rectangle.ex
+++ b/lib/scenic/primitive/rectangle.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Rectangle do
+  @moduledoc false
+
   use Scenic.Primitive
 
   @styles [:hidden, :fill, :stroke]

--- a/lib/scenic/primitive/rounded_rectangle.ex
+++ b/lib/scenic/primitive/rounded_rectangle.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.RoundedRectangle do
+  @moduledoc false
+
   use Scenic.Primitive
   alias Scenic.Primitive.Rectangle
 

--- a/lib/scenic/primitive/scene_ref.ex
+++ b/lib/scenic/primitive/scene_ref.ex
@@ -4,6 +4,7 @@
 #
 
 defmodule Scenic.Primitive.SceneRef do
+  @moduledoc false
   use Scenic.Primitive
 
   # ============================================================================

--- a/lib/scenic/primitive/sector.ex
+++ b/lib/scenic/primitive/sector.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Sector do
+  @moduledoc false
+
   use Scenic.Primitive
 
   # import IEx

--- a/lib/scenic/primitive/style/cap.ex
+++ b/lib/scenic/primitive/style/cap.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Cap do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # ============================================================================

--- a/lib/scenic/primitive/style/clear_color.ex
+++ b/lib/scenic/primitive/style/clear_color.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.ClearColor do
+  @moduledoc false
+
   use Scenic.Primitive.Style
   alias Scenic.Primitive.Style.Paint.Color
 

--- a/lib/scenic/primitive/style/fill.ex
+++ b/lib/scenic/primitive/style/fill.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Fill do
+  @moduledoc false
+
   use Scenic.Primitive.Style
   alias Scenic.Primitive.Style.Paint
 

--- a/lib/scenic/primitive/style/font.ex
+++ b/lib/scenic/primitive/style/font.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Font do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # import IEx

--- a/lib/scenic/primitive/style/font_blur.ex
+++ b/lib/scenic/primitive/style/font_blur.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.FontBlur do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # import IEx

--- a/lib/scenic/primitive/style/font_size.ex
+++ b/lib/scenic/primitive/style/font_size.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.FontSize do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # import IEx

--- a/lib/scenic/primitive/style/hidden.ex
+++ b/lib/scenic/primitive/style/hidden.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Hidden do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # ============================================================================

--- a/lib/scenic/primitive/style/join.ex
+++ b/lib/scenic/primitive/style/join.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Join do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # ============================================================================

--- a/lib/scenic/primitive/style/miter_limit.ex
+++ b/lib/scenic/primitive/style/miter_limit.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.MiterLimit do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # ============================================================================

--- a/lib/scenic/primitive/style/paint.ex
+++ b/lib/scenic/primitive/style/paint.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Paint do
+  @moduledoc false
+
   alias Scenic.Primitive.Style.Paint
 
   # ============================================================================

--- a/lib/scenic/primitive/style/paint/box_gradient.ex
+++ b/lib/scenic/primitive/style/paint/box_gradient.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Paint.BoxGradient do
+  @moduledoc false
+
   alias Scenic.Primitive.Style.Paint.Color
 
   # --------------------------------------------------------

--- a/lib/scenic/primitive/style/paint/color.ex
+++ b/lib/scenic/primitive/style/paint/color.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Paint.Color do
+  @moduledoc false
+
   # ============================================================================
   # data verification and serialization
 

--- a/lib/scenic/primitive/style/paint/image.ex
+++ b/lib/scenic/primitive/style/paint/image.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Paint.Image do
+  @moduledoc false
+
   # --------------------------------------------------------
   def normalize(image) when is_bitstring(image) do
     normalize({image, 0, 0, 0, 0, 0, 0xFF})

--- a/lib/scenic/primitive/style/paint/linear_gradient.ex
+++ b/lib/scenic/primitive/style/paint/linear_gradient.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Paint.LinearGradient do
+  @moduledoc false
+
   alias Scenic.Primitive.Style.Paint.Color
 
   # --------------------------------------------------------

--- a/lib/scenic/primitive/style/paint/radial_gradient.ex
+++ b/lib/scenic/primitive/style/paint/radial_gradient.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Paint.RadialGradient do
+  @moduledoc false
+
   alias Scenic.Primitive.Style.Paint.Color
 
   # --------------------------------------------------------

--- a/lib/scenic/primitive/style/scissor.ex
+++ b/lib/scenic/primitive/style/scissor.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Scissor do
+  @moduledoc false
+
   use Scenic.Primitive.Style
 
   # ============================================================================

--- a/lib/scenic/primitive/style/stroke.ex
+++ b/lib/scenic/primitive/style/stroke.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.Stroke do
+  @moduledoc false
+
   use Scenic.Primitive.Style
   alias Scenic.Primitive.Style.Paint
 

--- a/lib/scenic/primitive/style/style.ex
+++ b/lib/scenic/primitive/style/style.ex
@@ -3,10 +3,12 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-# the primitive style is not a primitive element in itself.
-# this is a type of styling that is applied to other primitive elements
-
 defmodule Scenic.Primitive.Style do
+  @moduledoc """
+  The primitive style is not a primitive element in itself.
+  This is a type of styling that is applied to other primitive elements.
+  """
+
   alias Scenic.Primitive.Style
 
   #  import IEx

--- a/lib/scenic/primitive/style/text_align.ex
+++ b/lib/scenic/primitive/style/text_align.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.TextAlign do
+  @moduledoc false
+
   use Scenic.Primitive.Style
   #  alias Scenic.Primitive.Style
 

--- a/lib/scenic/primitive/style/text_height.ex
+++ b/lib/scenic/primitive/style/text_height.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Style.TextHeight do
+  @moduledoc false
+
   use Scenic.Primitive.Style
   #  alias Scenic.Primitive.Style
 

--- a/lib/scenic/primitive/style/theme.ex
+++ b/lib/scenic/primitive/style/theme.ex
@@ -3,17 +3,17 @@
 #  Copyright © 2018 Kry10 Industries. All rights reserved.
 #
 
-# the theme style is a way to bundle up default colors that are
-# intended to be used by dynamic components invoked by a scene
-
-# there is a set of pre-defined themes. You can also pass
-# in a map of theme values
-
-# Unlike other styles, these are a guide to the components.
-# each component gets to pick, choose, or ignore any colors
-# in a given style
-
 defmodule Scenic.Primitive.Style.Theme do
+  @moduledoc """
+  The theme style is a way to bundle up default colors that are intended to be used by dynamic components invoked by a scene.
+
+  There is a set of pre-defined themes.
+  You can also pass in a map of theme values.
+
+  Unlike other styles, these are a guide to the components.
+  Each component gets to pick, choose, or ignore any colors in a given style.
+  """
+
   use Scenic.Primitive.Style
   alias Scenic.Primitive.Style.Paint.Color
 

--- a/lib/scenic/primitive/text.ex
+++ b/lib/scenic/primitive/text.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Text do
+  @moduledoc false
+
   use Scenic.Primitive
 
   @styles [:hidden, :fill, :font, :font_size, :font_blur, :text_align, :text_height]

--- a/lib/scenic/primitive/transform/matrix.ex
+++ b/lib/scenic/primitive/transform/matrix.ex
@@ -4,6 +4,7 @@
 #
 
 defmodule Scenic.Primitive.Transform.Matrix do
+  @moduledoc false
   use Scenic.Primitive.Transform
 
   @matrix_byte_size 16 * 4

--- a/lib/scenic/primitive/transform/pin.ex
+++ b/lib/scenic/primitive/transform/pin.ex
@@ -4,6 +4,7 @@
 #
 
 defmodule Scenic.Primitive.Transform.Pin do
+  @moduledoc false
   use Scenic.Primitive.Transform
 
   # ============================================================================

--- a/lib/scenic/primitive/transform/rotate.ex
+++ b/lib/scenic/primitive/transform/rotate.ex
@@ -4,6 +4,7 @@
 #
 
 defmodule Scenic.Primitive.Transform.Rotate do
+  @moduledoc false
   use Scenic.Primitive.Transform
 
   # ============================================================================

--- a/lib/scenic/primitive/transform/scale.ex
+++ b/lib/scenic/primitive/transform/scale.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Transform.Scale do
+  @moduledoc false
+
   use Scenic.Primitive.Transform
 
   # ============================================================================

--- a/lib/scenic/primitive/transform/transform.ex
+++ b/lib/scenic/primitive/transform/transform.ex
@@ -3,9 +3,11 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-# generic code for the transform styles. Not intended to be used directly
-
 defmodule Scenic.Primitive.Transform do
+  @moduledoc """
+  Generic code for the transform styles.
+  Not intended to be used directly
+  """
   alias Scenic.Math.Matrix
   alias Scenic.Math.Vector2
   alias Scenic.Primitive.Transform
@@ -15,6 +17,8 @@ defmodule Scenic.Primitive.Transform do
 
   # ===========================================================================
   defmodule FormatError do
+    @moduledoc false
+
     defexception message: nil, module: nil, data: nil
   end
 

--- a/lib/scenic/primitive/transform/translate.ex
+++ b/lib/scenic/primitive/transform/translate.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Transform.Translate do
+  @moduledoc false
+
   use Scenic.Primitive.Transform
 
   # ============================================================================

--- a/lib/scenic/primitive/triangle.ex
+++ b/lib/scenic/primitive/triangle.ex
@@ -4,6 +4,8 @@
 #
 
 defmodule Scenic.Primitive.Triangle do
+  @moduledoc false
+
   use Scenic.Primitive
   alias Scenic.Math
 

--- a/lib/scenic/view_port/config.ex
+++ b/lib/scenic/view_port/config.ex
@@ -7,6 +7,7 @@ defmodule Scenic.ViewPort.Config do
   @moduledoc """
   Helper module for configuring Drivers during startup.
   """
+
   alias Scenic.ViewPort.Driver
   alias Scenic.ViewPort.Config
   alias Scenic.Math

--- a/lib/scenic/view_port/config.ex
+++ b/lib/scenic/view_port/config.ex
@@ -2,9 +2,11 @@
 #  Created by Boyd Multerer April 2018.
 #  Copyright © 2018 Kry10 Industries. All rights reserved.
 #
-# helper module for configuring Drivers during startup
 
 defmodule Scenic.ViewPort.Config do
+  @moduledoc """
+  Helper module for configuring Drivers during startup.
+  """
   alias Scenic.ViewPort.Driver
   alias Scenic.ViewPort.Config
   alias Scenic.Math

--- a/lib/scenic/view_port/context.ex
+++ b/lib/scenic/view_port/context.ex
@@ -5,6 +5,8 @@
 # Seperate Context out into its own file
 
 defmodule Scenic.ViewPort.Context do
+  @moduledoc false
+
   alias Scenic.Math
   alias Scenic.Graph
   alias Scenic.ViewPort.Input

--- a/lib/scenic/view_port/driver.ex
+++ b/lib/scenic/view_port/driver.ex
@@ -3,12 +3,13 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-# each platform-specific version of scenic_platform must implement
-# a complient version of Scenic.ViewPort. There won't be any conflics
-# as by definition, there should be only one platform adapter in the
-# deps of any one build-type of a project.
+
 
 defmodule Scenic.ViewPort.Driver do
+  @moduledoc """
+  Each platform-specific version of scenic_platform must implement a complient version of `Scenic.ViewPort`.
+  There won't be any conflics as by definition, there should be only one platform adapter in the deps of any one build-type of a project.
+  """
   use GenServer
   alias Scenic.ViewPort
   alias Scenic.Math

--- a/lib/scenic/view_port/driver.ex
+++ b/lib/scenic/view_port/driver.ex
@@ -3,13 +3,12 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-
-
 defmodule Scenic.ViewPort.Driver do
   @moduledoc """
   Each platform-specific version of scenic_platform must implement a complient version of `Scenic.ViewPort`.
   There won't be any conflics as by definition, there should be only one platform adapter in the deps of any one build-type of a project.
   """
+
   use GenServer
   alias Scenic.ViewPort
   alias Scenic.Math

--- a/lib/scenic/view_port/driver/config.ex
+++ b/lib/scenic/view_port/driver/config.ex
@@ -7,6 +7,7 @@ defmodule Scenic.ViewPort.Driver.Config do
   @moduledoc """
   Helper module for configuring ViewPorts during startup
   """
+
   alias Scenic.ViewPort.Driver.Config
 
   # describe the struct. Name nil and opts as an empty list are good defaults

--- a/lib/scenic/view_port/driver/config.ex
+++ b/lib/scenic/view_port/driver/config.ex
@@ -2,9 +2,11 @@
 #  Created by Boyd Multerer April 2018.
 #  Copyright © 2018 Kry10 Industries. All rights reserved.
 #
-# helper module for configuring ViewPorts during startup
 
 defmodule Scenic.ViewPort.Driver.Config do
+  @moduledoc """
+  Helper module for configuring ViewPorts during startup
+  """
   alias Scenic.ViewPort.Driver.Config
 
   # describe the struct. Name nil and opts as an empty list are good defaults

--- a/lib/scenic/view_port/driver/info.ex
+++ b/lib/scenic/view_port/driver/info.ex
@@ -2,8 +2,11 @@
 #  Created by Boyd Multerer April 2018.
 #  Copyright © 2018 Kry10 Industries. All rights reserved.
 #
-# helper module for configuring ViewPorts during startup
 
 defmodule Scenic.ViewPort.Driver.Info do
+  @moduledoc """
+  Helper module for configuring ViewPorts during startup
+  """
+
   defstruct module: nil, type: nil, id: nil, width: -1, height: -1, pid: nil, private: nil
 end

--- a/lib/scenic/view_port/driver/supervisor.ex
+++ b/lib/scenic/view_port/driver/supervisor.ex
@@ -5,6 +5,7 @@
 
 defmodule Scenic.ViewPort.Driver.Supervisor do
   @moduledoc false
+
   use Supervisor
 
   # import IEx

--- a/lib/scenic/view_port/input.ex
+++ b/lib/scenic/view_port/input.ex
@@ -4,12 +4,13 @@
 #  Copyright © 2017 Kry10 Industries. All rights reserved.
 #
 
-# The main helpers and organizers for input
-
-# resizing is temporarily not supported
-
 defmodule Scenic.ViewPort.Input do
-  @moduledoc false
+  @moduledoc """
+  The main helpers and organizers for input.
+
+  *Resizing is temporarily not supported.*
+  """
+
   alias Scenic.Scene
   alias Scenic.ViewPort.Context
   alias Scenic.ViewPort

--- a/lib/scenic/view_port/status.ex
+++ b/lib/scenic/view_port/status.ex
@@ -5,6 +5,8 @@
 # Seperate Status out into its own file
 
 defmodule Scenic.ViewPort.Status do
+  @moduledoc false
+
   alias Scenic.ViewPort.Status
   alias Scenic.Math
 

--- a/lib/scenic/view_port/supervisor.ex
+++ b/lib/scenic/view_port/supervisor.ex
@@ -5,6 +5,7 @@
 
 defmodule Scenic.ViewPort.Supervisor do
   @moduledoc false
+
   use Supervisor
   alias Scenic.ViewPort
 

--- a/lib/scenic/view_port/supervisor_top.ex
+++ b/lib/scenic/view_port/supervisor_top.ex
@@ -8,6 +8,7 @@
 
 defmodule Scenic.ViewPort.SupervisorTop do
   @moduledoc false
+
   use Supervisor
   alias Scenic.ViewPort
 

--- a/lib/scenic/view_port/tables.ex
+++ b/lib/scenic/view_port/tables.ex
@@ -2,10 +2,13 @@
 #  Created by Boyd Multerer on 04/13/18.
 #  Copyright © 2018 Kry10 Industries. All rights reserved.
 #
-# The Tables processes is a critical piece of Scenic. It caches the graphs
-# that have been pushed by the various scenes.
 
 defmodule Scenic.ViewPort.Tables do
+  @moduledoc """
+  The Tables processes is a critical piece of Scenic.
+  It caches the graphs that have been pushed by the various scenes.
+  """
+
   use GenServer
   alias Scenic.Utilities
 

--- a/lib/utilities/enum.ex
+++ b/lib/utilities/enum.ex
@@ -1,6 +1,6 @@
 defmodule Scenic.Utilities.Enum do
   @moduledoc false
-  
+
   # ============================================================================
   def filter_reduce(enumerable, acc, action) when is_list(enumerable) do
     {filtered, acc} = do_filter_reduce_list(enumerable, {[], acc}, action)

--- a/lib/utilities/enum.ex
+++ b/lib/utilities/enum.ex
@@ -1,4 +1,6 @@
 defmodule Scenic.Utilities.Enum do
+  @moduledoc false
+  
   # ============================================================================
   def filter_reduce(enumerable, acc, action) when is_list(enumerable) do
     {filtered, acc} = do_filter_reduce_list(enumerable, {[], acc}, action)

--- a/lib/utilities/map.ex
+++ b/lib/utilities/map.ex
@@ -1,5 +1,5 @@
 defmodule Scenic.Utilities.Map do
-  @moduledoc false  
+  @moduledoc false
   #  @default_uid_length   4
 
   # ============================================================================

--- a/lib/utilities/map.ex
+++ b/lib/utilities/map.ex
@@ -1,4 +1,5 @@
 defmodule Scenic.Utilities.Map do
+  @moduledoc false  
   #  @default_uid_length   4
 
   # ============================================================================


### PR DESCRIPTION
## Description

This fixes the few score of complaints that Credo had about code readability: almost entirely due to the absence of `@moduledoc` in modules.


## Motivation and Context

This removes one of the remaining two categories of complaints that Credo has for us.

Fixes #64. 

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

No external changes, but does move some code comments into `@moduledoc` tags.

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
