### PR TITLE
Credo refactoring warnings appeasements

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -1,0 +1,160 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any exec using `mix credo -C <name>`. If no exec name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: ["lib/"],
+        excluded: [~r"/_build/", ~r"/.github/", ~r"/c_src/", ~r"/priv/", ~r"/deps", ~r"/guides/", ~r"/deps/"]
+      },
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        #
+        ## Consistency Checks
+        #
+        {Credo.Check.Consistency.ExceptionNames},
+        {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.ParameterPatternMatching},
+        {Credo.Check.Consistency.SpaceAroundOperators},
+        {Credo.Check.Consistency.SpaceInParentheses},
+        {Credo.Check.Consistency.TabsOrSpaces},
+
+        #
+        ## Design Checks
+        #
+        # You can customize the priority of any check
+        # Priority values are: `low, normal, high, higher`
+        #
+        {Credo.Check.Design.AliasUsage, priority: :low},
+        # For some checks, you can also set other parameters
+        #
+        # If you don't want the `setup` and `test` macro calls in ExUnit tests
+        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+        #
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        #
+        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagFIXME},
+
+        #
+        ## Readability Checks
+        #
+        {Credo.Check.Readability.AliasOrder},
+        {Credo.Check.Readability.FunctionNames},
+        {Credo.Check.Readability.LargeNumbers},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
+        {Credo.Check.Readability.ModuleAttributeNames},
+        {Credo.Check.Readability.ModuleDoc},
+        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+        {Credo.Check.Readability.ParenthesesInCondition},
+        {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.PreferImplicitTry},
+        {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.StringSigils},
+        {Credo.Check.Readability.TrailingBlankLine},
+        {Credo.Check.Readability.TrailingWhiteSpace},
+        {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Readability.Semicolons},
+        {Credo.Check.Readability.SpaceAfterCommas},
+
+        #
+        ## Refactoring Opportunities
+        #
+        {Credo.Check.Refactor.DoubleBooleanNegation},
+        {Credo.Check.Refactor.CondStatements},
+        {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.LongQuoteBlocks},
+        {Credo.Check.Refactor.MapInto},
+        {Credo.Check.Refactor.MatchInCondition},
+        {Credo.Check.Refactor.NegatedConditionsInUnless},
+        {Credo.Check.Refactor.NegatedConditionsWithElse},
+        {Credo.Check.Refactor.Nesting},
+        {Credo.Check.Refactor.PipeChainStart, false},
+        {Credo.Check.Refactor.UnlessWithElse},
+
+        #
+        ## Warnings
+        #
+        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
+        {Credo.Check.Warning.IExPry},
+        {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.LazyLogging},
+        {Credo.Check.Warning.OperationOnSameValues},
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedFileOperation},
+        {Credo.Check.Warning.UnusedKeywordOperation},
+        {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedPathOperation},
+        {Credo.Check.Warning.UnusedRegexOperation},
+        {Credo.Check.Warning.UnusedStringOperation},
+        {Credo.Check.Warning.UnusedTupleOperation},
+        {Credo.Check.Warning.RaiseInsideRescue},
+
+        #
+        # Controversial and experimental checks (opt-in, just remove `, false`)
+        #
+        {Credo.Check.Refactor.ABCSize, false},
+        {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.MapGetUnsafePass, false},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+
+        #
+        # Deprecated checks (these will be deleted after a grace period)
+        #
+        {Credo.Check.Readability.Specs, false}
+
+        #
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -22,7 +22,15 @@
         # In the latter case `**/*.{ex,exs}` will be used.
         #
         included: ["lib/"],
-        excluded: [~r"/_build/", ~r"/.github/", ~r"/c_src/", ~r"/priv/", ~r"/deps", ~r"/guides/", ~r"/deps/"]
+        excluded: [
+          ~r"/_build/",
+          ~r"/.github/",
+          ~r"/c_src/",
+          ~r"/priv/",
+          ~r"/deps",
+          ~r"/guides/",
+          ~r"/deps/"
+        ]
       },
       #
       # If you create your own checks, you must specify the source files for

--- a/lib/scenic/component/button.ex
+++ b/lib/scenic/component/button.ex
@@ -51,52 +51,14 @@ defmodule Scenic.Component.Button do
     alignment = styles[:alignment] || @default_alignment
 
     # build the graph
+
     graph =
-      case alignment do
-        :center ->
-          Graph.build(font: font, font_size: font_size)
-          |> rrect({width, height, radius}, fill: theme.background, id: :btn)
-          |> text(text,
-            fill: theme.text,
-            translate: {width / 2, height * 0.7},
-            text_align: :center,
-            id: :title
-          )
-
-        :left ->
-          Graph.build(font: font, font_size: font_size)
-          |> rrect({width, height, radius}, fill: theme.background, id: :btn)
-          |> text(
-            text,
-            fill: theme.text,
-            translate: {8, height * 0.7},
-            text_align: :left,
-            id: :title
-          )
-
-        :right ->
-          Graph.build(font: font, font_size: font_size)
-          |> rrect({width, height, radius}, fill: theme.background, id: :btn)
-          |> text(text,
-            fill: theme.text,
-            translate: {width - 8, height * 0.7},
-            text_align: :right,
-            id: :title
-          )
-      end
+      Graph.build(font: font, font_size: font_size)
+      |> rrect({width, height, radius}, fill: theme.background, id: :btn)
+      |> do_aligned_text(alignment, text, theme.text, width, height)
 
     # special case the dark and light themes to show an outline
-    graph =
-      case styles[:theme] do
-        :dark ->
-          Graph.modify(graph, :btn, &update_opts(&1, stroke: {1, theme.border}))
-
-        :light ->
-          Graph.modify(graph, :btn, &update_opts(&1, stroke: {1, theme.border}))
-
-        _ ->
-          graph
-      end
+    graph = do_special_theme_outline(styles[:theme], graph, theme.border)
 
     state = %{
       graph: graph,
@@ -110,6 +72,45 @@ defmodule Scenic.Component.Button do
     push_graph(graph)
 
     {:ok, state}
+  end
+
+  defp do_aligned_text(graph, :center, text, fill, width, height) do
+    text(graph, text,
+      fill: fill,
+      translate: {width / 2, height * 0.7},
+      text_align: :center,
+      id: :title
+    )
+  end
+
+  defp do_aligned_text(graph, :left, text, fill, _width, height) do
+    text(graph, text,
+      fill: fill,
+      translate: {8, height * 0.7},
+      text_align: :left,
+      id: :title
+    )
+  end
+
+  defp do_aligned_text(graph, :right, text, fill, width, height) do
+    text(graph, text,
+      fill: fill,
+      translate: {width - 8, height * 0.7},
+      text_align: :right,
+      id: :title
+    )
+  end
+
+  defp do_special_theme_outline(:dark, graph, border) do
+    Graph.modify(graph, :btn, &update_opts(&1, stroke: {1, border}))
+  end
+
+  defp do_special_theme_outline(:light, graph, border) do
+    Graph.modify(graph, :btn, &update_opts(&1, stroke: {1, border}))
+  end
+
+  defp do_special_theme_outline(_, graph, _border) do
+    graph
   end
 
   # --------------------------------------------------------

--- a/lib/scenic/component/input/dropdown.ex
+++ b/lib/scenic/component/input/dropdown.ex
@@ -60,6 +60,7 @@ defmodule Scenic.Component.Input.Dropdown do
   defp verify_item(_), do: false
 
   # --------------------------------------------------------
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def init({items, initial_id}, opts) do
     id = opts[:id]
     styles = opts[:styles]

--- a/lib/scenic/component/input/dropdown.ex
+++ b/lib/scenic/component/input/dropdown.ex
@@ -135,11 +135,19 @@ defmodule Scenic.Component.Input.Dropdown do
               g =
                 group(
                   g,
+                  # credo:disable-for-next-line Credo.Check.Refactor.Nesting
                   fn g ->
-                    case id == initial_id do
-                      true -> rect(g, {width, height}, fill: theme.active, id: id)
-                      false -> rect(g, {width, height}, fill: theme.background, id: id)
-                    end
+                    rect(
+                      g,
+                      {width, height},
+                      fill:
+                        if id == initial_id do
+                          theme.active
+                        else
+                          theme.background
+                        end,
+                      id: id
+                    )
                     |> text(text,
                       fill: theme.text,
                       text_align: :left,

--- a/lib/scenic/primitive/quad.ex
+++ b/lib/scenic/primitive/quad.ex
@@ -55,12 +55,13 @@ defmodule Scenic.Primitive.Quad do
         Math.Vector2.sub(p3, p0)
       )
 
-    width = if cross < 0 do
-      -width
-    else
-      width
-    end
-    
+    width =
+      if cross < 0 do
+        -width
+      else
+        width
+      end
+
     # find the new parallel lines
     l01 = Math.Line.parallel({p0, p1}, width)
     l12 = Math.Line.parallel({p1, p2}, width)

--- a/lib/scenic/primitive/quad.ex
+++ b/lib/scenic/primitive/quad.ex
@@ -55,12 +55,12 @@ defmodule Scenic.Primitive.Quad do
         Math.Vector2.sub(p3, p0)
       )
 
-    width =
-      cond do
-        cross < 0 -> -width
-        true -> width
-      end
-
+    width = if cross < 0 do
+      -width
+    else
+      width
+    end
+    
     # find the new parallel lines
     l01 = Math.Line.parallel({p0, p1}, width)
     l12 = Math.Line.parallel({p1, p2}, width)

--- a/lib/scenic/primitive/style/paint/color.ex
+++ b/lib/scenic/primitive/style/paint/color.ex
@@ -38,6 +38,8 @@ defmodule Scenic.Primitive.Style.Paint.Color do
   # ============================================================================
   # https://www.w3schools.com/colors/colors_names.asp
 
+  defguard is_uint8(x) when is_integer(x) and x >= 0 and x <= 255
+
   def to_rgba({:transparent, _}), do: to_rgba(:transparent)
   def to_rgba(:transparent), do: {0x80, 0x80, 0x80, 0x00}
   def to_rgba({:clear, _}), do: to_rgba(:transparent)
@@ -46,8 +48,7 @@ defmodule Scenic.Primitive.Style.Paint.Color do
   def to_rgba({r, g, b}), do: {r, g, b, 0xFF}
 
   def to_rgba({r, g, b, a})
-      when is_integer(r) and r >= 0 and r <= 255 and is_integer(g) and g >= 0 and g <= 255 and
-             is_integer(b) and b >= 0 and b <= 255 and is_integer(a) and a >= 0 and a <= 255 do
+      when is_uint8(r) and is_uint8(g) and is_uint8(b) and is_uint8(a) do
     {r, g, b, a}
   end
 

--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -575,6 +575,7 @@ defmodule Scenic.Scene do
             {:supervisor, Scene.Supervisor, _} ->
               dynamic_children_pid =
                 Supervisor.which_children(supervisor_pid)
+                # credo:disable-for-next-line Credo.Check.Refactor.Nesting
                 |> Enum.find_value(fn
                   {DynamicSupervisor, pid, :supervisor, [DynamicSupervisor]} -> pid
                   _ -> nil

--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -675,6 +675,7 @@ defmodule Scenic.ViewPort do
         case get_in(info, [:dictionary, :"$initial_call"]) do
           {:supervisor, Scenic.ViewPort.Supervisor, _} ->
             Supervisor.which_children(supervisor_pid)
+            # credo:disable-for-next-line Credo.Check.Refactor.Nesting
             |> Enum.find_value(fn
               {DynamicSupervisor, pid, :supervisor, [DynamicSupervisor]} -> pid
               _other -> nil

--- a/lib/utilities/map.ex
+++ b/lib/utilities/map.ex
@@ -98,6 +98,7 @@ defmodule Scenic.Utilities.Map do
   end
 
   # --------------------------------------------------------
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def apply_difference(map, diff_list, delete_empty \\ false)
       when is_map(map) and is_list(diff_list) do
     Enum.reduce(diff_list, map, fn diff, acc ->

--- a/lib/utilities/map.ex
+++ b/lib/utilities/map.ex
@@ -103,10 +103,11 @@ defmodule Scenic.Utilities.Map do
       case diff do
         {:put, {k0, k1}, v} ->
           map = Map.get(acc, k0, %{})
-
-          cond do
-            is_map(map) -> map
-            true -> %{}
+          
+          if is_map(map) do
+            map
+          else
+            %{}
           end
           |> apply_difference([{:put, k1, v}], delete_empty)
           |> (&Map.put(acc, k0, &1)).()

--- a/lib/utilities/map.ex
+++ b/lib/utilities/map.ex
@@ -60,6 +60,7 @@ defmodule Scenic.Utilities.Map do
         true ->
           v1 = Map.get(map_1, k)
 
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           case v1 == v do
             true -> d
             false -> add_difference(d, k, v1, v, recurse)
@@ -103,7 +104,7 @@ defmodule Scenic.Utilities.Map do
       case diff do
         {:put, {k0, k1}, v} ->
           map = Map.get(acc, k0, %{})
-          
+
           if is_map(map) do
             map
           else
@@ -120,6 +121,7 @@ defmodule Scenic.Utilities.Map do
             Map.get(acc, k0, %{})
             |> apply_difference([{:del, k1}], delete_empty)
 
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           case delete_empty && map == %{} do
             true -> Map.delete(acc, k0)
             false -> Map.put(acc, k0, map)

--- a/test/scenic/primitive/rounded_rectangle_test.exs
+++ b/test/scenic/primitive/rounded_rectangle_test.exs
@@ -59,11 +59,16 @@ defmodule Scenic.Primitive.RoundedRectangleTest do
   # ============================================================================
   # point containment
   test "contains_point? returns true if it contains the point" do
+    # center
     assert RoundedRectangle.contains_point?(@data, {20, 40}) == true
 
+    # center bottom
     assert RoundedRectangle.contains_point?(@data, {20, 0}) == true
+    # center top
     assert RoundedRectangle.contains_point?(@data, {20, 80}) == true
+    # center left
     assert RoundedRectangle.contains_point?(@data, {0, 40}) == true
+    # center right
     assert RoundedRectangle.contains_point?(@data, {40, 40}) == true
   end
 
@@ -85,6 +90,7 @@ defmodule Scenic.Primitive.RoundedRectangleTest do
 
   # ------------------------
   # negative width
+
   test "contains_point? returns true if it contains the point - negative width" do
     assert RoundedRectangle.contains_point?(@data_neg_w, {-20, 40}) == true
   end

--- a/test/scenic/primitive_test.exs
+++ b/test/scenic/primitive_test.exs
@@ -38,15 +38,6 @@ defmodule Scenic.PrimitiveTest do
     transforms: @transforms,
     styles: @styles
   }
-
-  # @primitive_2 %Primitive{
-  #   module:       @type_module,
-  #   data:         @data,
-  #   id:           {:test_id, 123},
-  #   transforms:   @transforms,
-  #   styles:       @styles,
-  # }
-
   @minimal_primitive %{
     data: {Group, @data},
     styles: %{
@@ -56,6 +47,23 @@ defmodule Scenic.PrimitiveTest do
     transforms: %{pin: {10, 11}, rotate: 0.1},
     id: :test_id
   }
+
+  @boring_primitive %Primitive{
+    module: @type_module,
+    data: []
+  }
+  @minimal_boring_primitive %{
+    data: {Group, []},
+    transforms: %{}
+  }
+
+  # @primitive_2 %Primitive{
+  #   module:       @type_module,
+  #   data:         @data,
+  #   id:           {:test_id, 123},
+  #   transforms:   @transforms,
+  #   styles:       @styles,
+  # }
 
   # ============================================================================
   # build( data, module, opts \\ [] )
@@ -308,6 +316,10 @@ defmodule Scenic.PrimitiveTest do
   # minimal
   test "minimal returns the minimal version of the prmitive" do
     assert Primitive.minimal(@primitive) == @minimal_primitive
+  end
+
+  test "minimal returns the minimal version of a boring primitive" do
+    assert Primitive.minimal(@boring_primitive) == @minimal_boring_primitive
   end
 
   # --------------------------------------------------------


### PR DESCRIPTION
## Description

This PR cleans up a bunch of refactoring warnings from credo:

* Pipeline warnings about starting with the wrong thing--mostly muted
* Warnings about use two-case `cond` instead of `if` statements, mostly fixed.
* Fixes, mostly muting, of excessive nesting.
* Several cyclomatic complexity warnings, generally fixed by moving logic into helper functions. This is especially done in the **rounded-rectangle picking code** and the **minimum primitive generation code**, and muted in a couple other places. *Please review (**and test!**) those changes before merging this!*

This PR also does two more things:

* Changes (hopefully simplifying) the rounded rectangle picking code. The new version calculates the distance from the pick point against the nearest point on the interior rectangle instead of the old outer-rectangle-plus-corner-radii test.
* Adds a basic credo config we can start tweaking and make more reasonable. This is how the pipeline stuff was addressed. 

## Motivation and Context

This is for fixing #67 .

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
