### PR TITLE
Fixes typo/link in overview styles guide

### DIFF
--- a/guides/overview_styles.md
+++ b/guides/overview_styles.md
@@ -25,7 +25,7 @@ For example, to use the style defined in the module Scenic.Primitive.Style.Font 
 * [`MiterLimit`](Scenic.Primitive.Style.MiterLimit.html) sets whether or not to miter a joint if the intersection of two lines is very sharp.
 * [`Scissor`](Scenic.Primitive.Style.Scissor.html) defines a rectangle that drawing will be clipped to.
 * [`Stroke`](Scenic.Primitive.Style.Stroke.html) defines how to draw the edge of a primitive. Specifies both a width and a [paint style](overview_styles.html#primitive-paint-styles).
-* [`TextAign`](Scenic.Primitive.Style.TextAign.html) sets the alignment of text relative to the starting point. Examples: :left, :center, or :right
+* [`TextAlign`](Scenic.Primitive.Style.TextAlign.html) sets the alignment of text relative to the starting point. Examples: :left, :center, or :right
 * [`Theme`](Scenic.Primitive.Style.Theme.html) a collection of default colors. Usually passed to components, telling them how to draw in your preferred color scheme.
 
 ## Primitive Paint Styles


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

Thanks for Scenic! I'm just getting started with it, and while reading the docs, I found a broken link in the [styles overview](https://hexdocs.pm/scenic/overview_styles.html#primitive-styles) section due to a typo. 

This fixes the typo and the associated link, changing it from `TextAign` to `TextAlign`.
