### PR TITLE
Fix dialyzer specs for %Graph{}

### DIFF
--- a/lib/scenic/graph.ex
+++ b/lib/scenic/graph.ex
@@ -144,7 +144,7 @@ defmodule Scenic.Graph do
           primitives: map,
           ids: map,
           next_uid: pos_integer,
-          add_to: pos_integer
+          add_to: non_neg_integer
         }
 
   @type key :: {:graph, Scenic.Scene.ref(), any}
@@ -730,7 +730,7 @@ defmodule Scenic.Graph do
   @spec modify(
           graph :: t(),
           id :: any | (any -> as_boolean(term())),
-          action :: (... -> Primitive.t())
+          action :: (any -> Primitive.t())
         ) :: t()
   def modify(graph, id, action)
 


### PR DESCRIPTION
## Description

The default `add_to` value is 0 which does not match the current spec of
`pos_integer` but does match `non_neg_integer`. Also since the action function only accepts one argument in the code, enforce that at the spec level as well.

## Motivation and Context

This fixes a dialyzer issue when dialyzer is run on a `scenic.new` project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
