### PR TITLE
Delete members of group when deleting group

### DIFF
--- a/test/scenic/graph_test.exs
+++ b/test/scenic/graph_test.exs
@@ -163,6 +163,30 @@ defmodule Scenic.GraphTest do
     refute Enum.member?(deleted.primitives[puid].data, uid)
   end
 
+  test "delete a group removes group children" do
+    [tuid] = @graph_find.ids[:inner_text]
+    [luid] = @graph_find.ids[:inner_line]
+    refute @graph_find.primitives[tuid] == nil
+    refute @graph_find.primitives[luid] == nil
+    deleted = Graph.delete(@graph_find, :group)
+    assert Graph.get(deleted, :inner_text) == []
+    assert deleted.ids[:inner_text] == nil
+    assert Graph.get(deleted, :inner_line) == []
+    assert deleted.ids[:inner_line] == nil
+  end
+
+  @graph_find Graph.build()
+              |> Text.add_to_graph("Some sample text", id: :outer_text)
+              |> Line.add_to_graph({{10, 10}, {100, 100}}, id: :outer_line)
+              |> Group.add_to_graph(
+                fn g ->
+                  g
+                  |> Text.add_to_graph("inner text", id: :inner_text)
+                  |> Line.add_to_graph({{10, 10}, {100, 100}}, id: :inner_line)
+                end,
+                id: :group
+              )
+
   # ============================================================================
   # count - all nodes
   test "count returns 1 if only the root node exists" do

--- a/test/scenic/graph_test.exs
+++ b/test/scenic/graph_test.exs
@@ -175,18 +175,6 @@ defmodule Scenic.GraphTest do
     assert deleted.ids[:inner_line] == nil
   end
 
-  @graph_find Graph.build()
-              |> Text.add_to_graph("Some sample text", id: :outer_text)
-              |> Line.add_to_graph({{10, 10}, {100, 100}}, id: :outer_line)
-              |> Group.add_to_graph(
-                fn g ->
-                  g
-                  |> Text.add_to_graph("inner text", id: :inner_text)
-                  |> Line.add_to_graph({{10, 10}, {100, 100}}, id: :inner_line)
-                end,
-                id: :group
-              )
-
   # ============================================================================
   # count - all nodes
   test "count returns 1 if only the root node exists" do


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

This PR updates the functionality of Graph.delete in order to delete members of a group when a group is deleted. If group members are themselves groups, members of those groups are also deleted.

## Motivation and Context

When deleting a group, members of the group should also be deleted. This is consistent with the [documentation](https://hexdocs.pm/scenic/Scenic.Graph.html#delete/2).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [X] Check other PRs and make sure that the changes are not done yet.
- [X] The PR title is no longer than 64 characters.
