### PR TITLE
Move C build products under _build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@
 # ERL_EI_LIBDIR path to libei.a
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
+# MIX_COMPILE_PATH path to the build's ebin directory
+
+PREFIX = $(MIX_COMPILE_PATH)/../priv
+BUILD  = $(MIX_COMPILE_PATH)/../obj
 
 # Look for the EI library and header files
 # For crosscompiled builds, ERL_EI_INCLUDE_DIR and ERL_EI_LIBDIR must be
@@ -25,12 +29,12 @@ LDFLAGS += -undefined dynamic_lookup
 endif
 endif
 
-NIF=priv/line.so priv/matrix.so
+NIF=$(PREFIX)/line.so $(PREFIX)/matrix.so
 
 calling_from_make:
 	mix compile
 
-all: priv $(NIF)
+all: $(PREFIX) $(BUILD) $(NIF)
 
 pull_deps:
 	mix local.hex --force
@@ -47,17 +51,17 @@ unit_test:
 docs_report:
 	mix inch.report
 
-priv:
-	mkdir -p priv
-
-%.o: %.c
+$(BUILD)/%.o: c_src/%.c
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
-priv/line.so: c_src/line.o
+$(PREFIX)/line.so: $(BUILD)/line.o
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 
-priv/matrix.so: c_src/matrix.o
+$(PREFIX)/matrix.so: $(BUILD)/matrix.o
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
+
+$(PREFIX) $(BUILD):
+	mkdir -p $@
 
 clean:
 	$(RM) $(NIF) c_src/*.o

--- a/mix.exs
+++ b/mix.exs
@@ -14,12 +14,11 @@ defmodule Scenic.Mixfile do
       version: @version,
       elixir: @elixir_version,
       deps: deps(),
-      build_embedded: Mix.env() == :prod,
+      build_embedded: true,
       start_permanent: Mix.env() == :prod,
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
-      make_env: make_env(),
       name: "Scenic",
       description: description(),
       docs: docs(),
@@ -36,19 +35,6 @@ defmodule Scenic.Mixfile do
     """
   end
 
-  defp make_env do
-    case System.get_env("ERL_EI_INCLUDE_DIR") do
-      nil ->
-        %{
-          "ERL_EI_INCLUDE_DIR" => "#{:code.root_dir()}/usr/include",
-          "ERL_EI_LIBDIR" => "#{:code.root_dir()}/usr/lib"
-        }
-
-      _ ->
-        %{}
-    end
-  end
-
   def application do
     [
       # mod: {Scenic, []},
@@ -58,7 +44,7 @@ defmodule Scenic.Mixfile do
 
   defp deps do
     [
-      {:elixir_make, "~> 0.4"},
+      {:elixir_make, "~> 0.5", runtime: false},
 
       # Tools
       {:ex_doc, ">= 0.0.0", only: :dev},


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

The build products were being stored in the source directory. This was
causing trouble when building for different architectures since build
products for one could be used for the other. The workaround was to
build clean when switching. `elixir_make` v0.5.0 makes it easier to move
build products under the appropriate directory under `_build` by
exporting the `MIX_COMPILE_PATH` environment variable. This updates the
`elixir_make` dep to at least v0.5.0 and uses the new environment
variables.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
