### PR TITLE
Add specs to components

### DIFF
--- a/lib/scenic/components.ex
+++ b/lib/scenic/components.ex
@@ -191,7 +191,13 @@ defmodule Scenic.Components do
     modify(p, Component.Button, data, options)
   end
 
-  # --------------------------------------------------------
+  @doc """
+  Generate an uninstantiated button spec, parallel to the concept of
+  primitive specs. This allows buttons to be treated as data.
+  """
+  def button_spec(data, options), do: &button(&1, data, options)
+
+    # --------------------------------------------------------
   @doc """
   Add a [`Checkbox`](Scenic.Component.Input.Checkbox.html) to a graph
 
@@ -252,6 +258,12 @@ defmodule Scenic.Components do
   def checkbox(%Primitive{module: SceneRef} = p, data, options) do
     modify(p, Component.Input.Checkbox, data, options)
   end
+
+  @doc """
+  Generate an uninstantiated checkbox spec, parallel to the concept of
+  primitive specs. See `Components.checkbox` for data and options values.
+  """
+  def checkbox_spec(data, options), do: &checkbox(&1, data, options)
 
   # --------------------------------------------------------
   @doc """
@@ -342,6 +354,13 @@ defmodule Scenic.Components do
     modify(p, Component.Input.Dropdown, data, options)
   end
 
+  @doc """
+  Generate an uninstantiated dropdown spec, parallel to the concept of
+  primitive specs. See `Components.dropdown` for data and options values.
+  """
+  def dropdown_spec(data, options), do: &dropdown(&1, data, options)
+
+
   # --------------------------------------------------------
   @doc """
   Add a [`RadioGroup`](Scenic.Component.Input.RadioGroup.html) to a graph
@@ -425,6 +444,12 @@ defmodule Scenic.Components do
     modify(p, Component.Input.RadioGroup, data, options)
   end
 
+  @doc """
+  Generate an uninstantiated radio_group spec, parallel to the concept of
+  primitive specs. See `Components.radio_group` for data and options values.
+  """
+  def radio_group_spec(data, options), do: &radio_group(&1, data, options)
+
   # --------------------------------------------------------
   @doc """
   Add a [`Slider`](Scenic.Component.Input.Slider.html) to a graph
@@ -503,6 +528,12 @@ defmodule Scenic.Components do
   def slider(%Primitive{module: SceneRef} = p, data, options) do
     modify(p, Component.Input.Slider, data, options)
   end
+
+  @doc """
+  Generate an uninstantiated slider spec, parallel to the concept of
+  primitive specs. See `Components.slider` for data and options values.
+  """
+  def slider_spec(data, options), do: &slider(&1, data, options)
 
   # --------------------------------------------------------
   @doc """
@@ -587,6 +618,12 @@ defmodule Scenic.Components do
   end
 
   @doc """
+  Generate an uninstantiated text_field spec, parallel to the concept of
+  primitive specs. See `Components.text_field` for data and options values.
+  """
+  def text_field_spec(data, options), do: &text_field(&1, data, options)
+
+  @doc """
   Add [`Toggle`](Scenic.Component.Input.Toggle.html) to a Scenic graph.
 
   ### Data
@@ -644,6 +681,12 @@ defmodule Scenic.Components do
   def toggle(%Primitive{module: SceneRef} = p, data, options) do
     modify(p, Component.Input.Toggle, data, options)
   end
+
+  @doc """
+  Generate an uninstantiated toggle spec, parallel to the concept of
+  primitive specs. See `Components.toggle` for data and options values.
+  """
+  def toggle_spec(data, options), do: &toggle(&1, data, options)
 
   # ============================================================================
   # generic workhorse versions

--- a/lib/scenic/primitives.ex
+++ b/lib/scenic/primitives.ex
@@ -242,6 +242,7 @@ defmodule Scenic.Primitives do
   def add_specs_to_graph(g, list, options) when is_list(list) do
     display_list = fn g ->
       list
+      |> List.flatten
       |> Enum.reduce(g, fn item, g -> item.(g) end)
     end
 

--- a/test/scenic/components_test.exs
+++ b/test/scenic/components_test.exs
@@ -8,6 +8,7 @@ defmodule Scenic.ComponentsTest do
   doctest Scenic.Components
   alias Scenic.Graph
   alias Scenic.Primitive
+  alias Scenic.Primitives
   alias Scenic.Components
 
   @graph Graph.build()
@@ -45,6 +46,18 @@ defmodule Scenic.ComponentsTest do
     assert p.id == :modified
   end
 
+  test "button_spec adds a button to the graph" do
+    spec = Components.button_spec("Name1", id: :button1)
+    result =
+      @graph
+      |> Primitives.add_specs_to_graph([ spec ])
+      |> Graph.get!(:button1)
+
+    assert result.module == Primitive.SceneRef
+    assert result.data == {Scenic.Component.Button, "Name1"}
+    assert result.id == :button1
+  end
+
   # ============================================================================
   test "checkbox adds to a graph - default opts" do
     g = Components.checkbox(@graph, {"Name", true})
@@ -80,6 +93,18 @@ defmodule Scenic.ComponentsTest do
     assert p.id == :modified
   end
 
+  test "checkbox_spec adds a checkbox to the graph" do
+    spec = Components.checkbox_spec({"Name1", true}, id: :checkbox1)
+    result =
+      @graph
+      |> Primitives.add_specs_to_graph([ spec ])
+      |> Graph.get!(:checkbox1)
+
+    assert result.module == Primitive.SceneRef
+    assert result.data == {Scenic.Component.Input.Checkbox, {"Name1", true}}
+    assert result.id == :checkbox1
+  end
+
   # ============================================================================
   @drop_data {[{"a", 1}, {"b", 2}], 2}
 
@@ -111,6 +136,18 @@ defmodule Scenic.ComponentsTest do
 
     assert p.data == {Scenic.Component.Input.Dropdown, mod_data}
     assert p.id == :modified
+  end
+
+  test "dropdown_spec adds a dropdown to the graph" do
+    spec = Components.dropdown_spec(@drop_data, id: :dropdown1)
+    result =
+      @graph
+      |> Primitives.add_specs_to_graph([ spec ])
+      |> Graph.get!(:dropdown1)
+
+    assert result.module == Primitive.SceneRef
+    assert result.data == {Scenic.Component.Input.Dropdown, @drop_data}
+    assert result.id == :dropdown1
   end
 
   # ============================================================================
@@ -145,6 +182,19 @@ defmodule Scenic.ComponentsTest do
     assert p.data == {Scenic.Component.Input.RadioGroup, mod_data}
     assert p.id == :modified
   end
+
+  test "radio_group_spec adds a radio_group to the graph" do
+    spec = Components.radio_group_spec(@radio_data, id: :radio_group1)
+    result =
+      @graph
+      |> Primitives.add_specs_to_graph([ spec ])
+      |> Graph.get!(:radio_group1)
+
+    assert result.module == Primitive.SceneRef
+    assert result.data == {Scenic.Component.Input.RadioGroup, @radio_data}
+    assert result.id == :radio_group1
+  end
+
 
   # ============================================================================
   @slider_int_data {{0, 100}, 20}
@@ -193,6 +243,18 @@ defmodule Scenic.ComponentsTest do
     assert p.id == :modified
   end
 
+  test "slider_spec adds a slider to the graph" do
+    spec = Components.slider_spec(@slider_int_data, id: :slider1)
+    result =
+      @graph
+      |> Primitives.add_specs_to_graph([ spec ])
+      |> Graph.get!(:slider1)
+
+    assert result.module == Primitive.SceneRef
+    assert result.data == {Scenic.Component.Input.Slider, @slider_int_data}
+    assert result.id == :slider1
+  end
+
   # ============================================================================
   test "text_field adds to a graph - default opts" do
     g = Components.text_field(@graph, "Name")
@@ -220,6 +282,19 @@ defmodule Scenic.ComponentsTest do
 
     assert p.data == {Scenic.Component.Input.TextField, "Modified"}
     assert p.id == :modified
+  end
+
+
+  test "text_field_spec adds a text_field to the graph" do
+    spec = Components.text_field_spec("wibble", id: :text_field1)
+    result =
+      @graph
+      |> Primitives.add_specs_to_graph([ spec ])
+      |> Graph.get!(:text_field1)
+
+    assert result.module == Primitive.SceneRef
+    assert result.data == {Scenic.Component.Input.TextField, "wibble"}
+    assert result.id == :text_field1
   end
 
   # ============================================================================
@@ -256,4 +331,17 @@ defmodule Scenic.ComponentsTest do
     assert p.data == {Scenic.Component.Input.Toggle, false}
     assert p.id == :modified
   end
+
+  test "toggle_spec adds a toggle to the graph" do
+    spec = Components.toggle_spec(true, id: :toggle1)
+    result =
+      @graph
+      |> Primitives.add_specs_to_graph([ spec ])
+      |> Graph.get!(:toggle1)
+
+    assert result.module == Primitive.SceneRef
+    assert result.data == {Scenic.Component.Input.Toggle, true}
+    assert result.id == :toggle1
+  end
+
 end


### PR DESCRIPTION
This adds _spec versions of all the components. These are just curried forms of the original, and are reified by passing the they return a graph value. This is typically done using `add_specs_to_graph`