### PR TITLE
DON'T MERGE THIS...IT'S JUST A QUICK HACK PARTIAL FIX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: elixir
 sudo: required
 
+branches:
+  only:
+  - /.*/
+
 elixir:
   - 1.8
 otp_release:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ pull_deps:
 	mix local.hex --force
 	mix local.rebar --force
 	mix deps.get
+	mkdir -p priv/static/font_metrics
+	cp -r deps/font_metrics/test/metrics/*.ttf.metrics priv/static/font_metrics
 
 linter:
 	mix format --check-formatted

--- a/lib/scenic/cache/base.ex
+++ b/lib/scenic/cache/base.ex
@@ -919,8 +919,7 @@ defmodule Scenic.Cache.Base do
       """
       Cache subscription type #{inspect(old)} is deprecated
       Please use #{inspect(new)} instead
-      """ <>
-      IO.ANSI.default_color()
+      """ <> IO.ANSI.default_color()
 
     do_subscribe(service, hash, new)
   end
@@ -968,8 +967,7 @@ defmodule Scenic.Cache.Base do
       """
       Cache subscription type #{inspect(old)} is deprecated
       Please use #{inspect(new)} instead
-      """ <>
-      IO.ANSI.default_color()
+      """ <> IO.ANSI.default_color()
 
     do_unsubscribe(service, hash, new)
   end

--- a/test/scenic/cache/dynamic/texture_test.exs
+++ b/test/scenic/cache/dynamic/texture_test.exs
@@ -110,11 +110,9 @@ defmodule Scenic.Cache.Dynamic.TextureTest do
   end
 
   test "load passes through errors" do
-    assert Texture.load(@parrot_hash, "wrong/path", []) ==
-             {:error, :enoent}
+    assert Texture.load(@parrot_hash, "wrong/path", []) == {:error, :enoent}
 
-    assert Texture.load("bad_hash", @parrot_path, []) ==
-             {:error, :hash_failure}
+    assert Texture.load("bad_hash", @parrot_path, []) == {:error, :hash_failure}
   end
 
   # ============================================================================

--- a/test/scenic/cache/static/font_metrics_test.exs
+++ b/test/scenic/cache/static/font_metrics_test.exs
@@ -112,11 +112,9 @@ defmodule Scenic.Cache.Static.FontMetricsTest do
   end
 
   test "load passes through errors" do
-    assert Static.FontMetrics.load(@roboto_hash, "wrong/path") ==
-             {:error, :enoent}
+    assert Static.FontMetrics.load(@roboto_hash, "wrong/path") == {:error, :enoent}
 
-    assert Static.FontMetrics.load("bad_hash", @roboto_path) ==
-             {:error, :hash_failure}
+    assert Static.FontMetrics.load("bad_hash", @roboto_path) == {:error, :hash_failure}
   end
 
   # ============================================================================

--- a/test/scenic/cache/static/font_test.exs
+++ b/test/scenic/cache/static/font_test.exs
@@ -115,11 +115,9 @@ defmodule Scenic.Cache.Static.FontTest do
   end
 
   test "load passes through errors" do
-    assert Font.load(@hash, "wrong/path") ==
-             {:error, :not_found}
+    assert Font.load(@hash, "wrong/path") == {:error, :not_found}
 
-    assert Font.load("bad_hash", @folder) ==
-             {:error, :hash_failure}
+    assert Font.load("bad_hash", @folder) == {:error, :hash_failure}
   end
 
   # ============================================================================

--- a/test/scenic/cache/static/texture_test.exs
+++ b/test/scenic/cache/static/texture_test.exs
@@ -110,11 +110,9 @@ defmodule Scenic.Cache.Static.TextureTest do
   end
 
   test "load passes through errors" do
-    assert Texture.load(@parrot_hash, "wrong/path", []) ==
-             {:error, :enoent}
+    assert Texture.load(@parrot_hash, "wrong/path", []) == {:error, :enoent}
 
-    assert Texture.load("bad_hash", @parrot_path, []) ==
-             {:error, :hash_failure}
+    assert Texture.load("bad_hash", @parrot_path, []) == {:error, :hash_failure}
   end
 
   # ============================================================================

--- a/test/scenic/cache/support/file_test.exs
+++ b/test/scenic/cache/support/file_test.exs
@@ -97,8 +97,7 @@ defmodule Scenic.Cache.Support.FileTest do
   end
 
   test "read handles unzip errors" do
-    assert Support.File.read(@sample_path, @sample_sha, decompress: true) ==
-             {:error, :decompress}
+    assert Support.File.read(@sample_path, @sample_sha, decompress: true) == {:error, :decompress}
   end
 
   # ============================================================================


### PR DESCRIPTION
This PR just shows a quick fix to get the ball rolling (and the test suite failing instead of just bombing out earlier).

Two problems:

* The directory this thing is looking for (`priv/static/font_metrics`) doesn't exist, so the makefile just hacks one in.
* The source ttf metrics files also don't exist, so we pull them out of the first place that looks like it has them (the `font_metrics` dep). **However**, that's missing one of the three fonts that are expected, so you either need to find that one or copy the roboto one again and rename it...which aggravates the test gods.

But, that should be enough to get things going again.