### PR TITLE
Include recipe for copying static files to priv in Makefile.win

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -10,6 +10,7 @@ CC=cl
 LINK=link
 NMAKE = nmake /$(MAKEFLAGS)
 
+STATIC = priv\static
 SRC_DIR = c_src
 
 # Scenic.Math.Line.parallel({{1,2},{3,4}}, 4)
@@ -17,13 +18,17 @@ SRC_DIR = c_src
 calling_from_make:
 	mix compile
 
-all: clean priv Makefile.auto.win NIF
+all: clean priv $(STATIC) Makefile.auto.win NIF
 
 clean:
 	del /Q /F priv
 
 priv:
 	mkdir priv
+
+$(STATIC):
+	mkdir $(STATIC)
+	xcopy /S /E /Y static $(STATIC)
 
 Makefile.auto.win:
 	erl -eval "io:format(\"~s~n\", [lists:concat([\"ERTS_INCLUDE_PATH=\", code:root_dir(), \"/erts-\", erlang:system_info(version), \"/include\"])])" -s init stop -noshell > $@


### PR DESCRIPTION
## Description

In a recent change, the copying of static assets became a part in the build process described by the Makefile. This patch ports this step to the Windows makefile.

## Motivation and Context

Currently, the build process fails on Windows due to the following error:

```sh
== Compilation error in file lib/scenic/cache/static/font_metrics.ex ==
** (File.Error) could not stream ".../_build/test/lib/scenic/priv/static/font_metrics/R
oboto-Regular.ttf.metrics": no such file or directory
    (elixir) lib/file/stream.ex:83: anonymous fn/3 in Enumerable.File.Stream.reduce/3
    (elixir) lib/stream.ex:1377: anonymous fn/5 in Stream.resource/3
    (elixir) lib/enum.ex:3015: Enum.reduce/3
    lib/scenic/cache/support/hash.ex:110: Scenic.Cache.Support.Hash.file!/2
    lib/scenic/cache/static/font_metrics.ex:125: (module)
could not compile dependency :scenic, "mix compile" failed. You can recompile this dependency with "mix deps.compile sce
nic", update it with "mix deps.update scenic" or clean it with "mix deps.clean scenic"
```

Most importantly, this change will enable boydm/scenic_driver_glfw#21 .

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
