### PR TITLE
Add spaces in scene crashed message for readability

### DIFF
--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -921,10 +921,10 @@ defmodule Scenic.Scene do
           [
             "\n",
             IO.ANSI.red(),
-            module_msg <> "crashed during init",
+            module_msg <> " crashed during init",
             "\n",
             IO.ANSI.yellow(),
-            "Scene Args:" <> args_msg,
+            "Scene Args: " <> args_msg,
             "\n",
             IO.ANSI.red(),
             err_msg,


### PR DESCRIPTION
## Description

Improve readability of the printed error when a scene crashes on init by adding spaces.

## Motivation and Context

My scene crashed due to misconfiguration on my part and the error needed some spaces.

Before:
```
Demo.Scene.Homecrashed during init
Scene Args:nil
```

After:
```
Demo.Scene.Home crashed during init
Scene Args: nil
```

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
