### PR TITLE
Allow handle_continue/2 to be overridden in a Scene

### DIFF
--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -585,7 +585,7 @@ defmodule Scenic.Scene do
       @doc false
       def handle_info(_msg, state), do: {:noreply, state}
       @doc false
-      def handle_continue(_msg, state), do: {:noreply, nil, state}
+      def handle_continue(_msg, state), do: {:noreply, state}
 
       @doc false
       def handle_input(event, _, scene_state), do: {:noreply, scene_state}
@@ -645,7 +645,7 @@ defmodule Scenic.Scene do
             {:reply, reply, state, push: graph}
             {:noreply, state, push: graph}
 
-        from handle_continue/3
+        from handle_continue/2
             {:noreply, state, push: graph}
         #{IO.ANSI.default_color()}
         """)
@@ -676,6 +676,7 @@ defmodule Scenic.Scene do
       # --------------------------------------------------------
       defoverridable handle_call: 3,
                      handle_cast: 2,
+                     handle_continue: 2,
                      handle_info: 2,
                      handle_input: 3,
                      filter_event: 3,


### PR DESCRIPTION
## Description

Allow `handle_continue/2` to be overridden in a Scene. Without this the default function supplied by `use Scenic.Scene` always matches.

I also made a small doc fix and changed the default `handle_continue/2` to simply return `{:noreply, state}`

## Motivation and Context

I discovered this while trying to use `:continue` from my scene's `init/2` implementation to kick off a ticker for animations.

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
