### PR TITLE
Add deferred primitive helper for group

### DIFF
--- a/test/scenic/primitives_test.exs
+++ b/test/scenic/primitives_test.exs
@@ -185,6 +185,19 @@ defmodule Scenic.PrimitivesTest do
     assert p.id == :group
   end
 
+  test "group adds via reverse spec" do
+    p =
+      @graph
+      |> Primitives.add_specs_to_graph([
+        Primitives.group_spec_r([id: :group], [])
+      ])
+      |> Graph.get!(:group)
+
+    assert p.module == Scenic.Primitive.Group
+    assert p.data == []
+    assert p.id == :group
+  end
+
   # ============================================================================
   test "line adds to a graph - default opts" do
     g = Primitives.line(@graph, {{0, 0}, {10, 100}})


### PR DESCRIPTION
## Description

I noticed that code was getting a bit messy and wanted to put grouping options before the group children.

## Motivation and Context

I found that `mix format`ed code ended up looking messy as well as hard to read (as a human) since it put, for example, translation options far away from the `group_spec` call.

I don't think large graphs get much cleaner than this, without a bit of effort in how specs are represented:

``` elixir
@graph Graph.build(font: :roboto, font_size: 16)
        |> add_specs_to_graph([
          group_spec_r([t: {0, 500}], [
            group_spec_r([t: {500, 0}], [
              button_spec("button 1", t: {0, 0}),
              button_spec("button 2", t: {50, 0})
            ]),
            group_spec_r([t: {600, 0}], [
              button_spec("button A", t: {0, 0}),
              button_spec("button B", t: {50, 0})
            ])
          ]),
          group_spec_r([t: {140, 0}], [
            # this was left out in the other example because it cluttered it
            group_spec_r([t: {0, 110}], [
              Rotary.rotary_spec(0.0, id: {:chan, {:lmf, :q}}, mode: :fill, t: {180, 0}),
              Rotary.rotary_spec(0.0, id: {:chan, {:hmf, :q}}, mode: :fill, t: {220, 0})
            ]),
            # this was left out in the other example because it cluttered it
            group_spec_r([t: {0, 160}], [
              Rotary.add_to_graph(0.0, id: {:chan, {:hpf, :hz}}, mode: :fill, t: {100, 0}),
              Rotary.add_to_graph(0.0, id: {:chan, {:lf, :hz}}, mode: :fill, t: {140, 0}),
              Rotary.add_to_graph(0.0, id: {:chan, {:lmf, :hz}}, mode: :fill, t: {180, 0}),
              Rotary.add_to_graph(0.0, id: {:chan, {:hmf, :hz}}, mode: :fill, t: {220, 0}),
              Rotary.add_to_graph(0.0, id: {:chan, {:hf, :hz}}, mode: :fill, t: {260, 0}),
              Rotary.add_to_graph(0.0, id: {:chan, {:lpf, :hz}}, mode: :fill, t: {300, 0})
            ]),
            group_spec_r([t: {0, 350}], [
              Rotary.rotary_spec(0.50, id: {:chan, {:lf, :db}}, mode: :center, t: {0, 0}),
              Rotary.rotary_spec(0.50, id: {:chan, {:lmf, :db}}, mode: :center, t: {40, 0}),
              Rotary.rotary_spec(0.50, id: {:chan, {:hmf, :db}}, mode: :center, t: {80, 0}),
              Rotary.rotary_spec(0.50, id: {:chan, {:hf, :db}}, mode: :center, t: {120, 0})
            ])
          ])
        ])
```

The most readable I've found I can get it without `group_spec_r` is the following, but lines are wasted instead...

``` elixir
@top_button_grid [
  group_spec(
    [
      button_spec("button 1", translate: {0, 0}),
      button_spec("button 2", translate: {50, 0})
    ],
    translate: {500, 0}
  ),
  group_spec(
    [
      button_spec("button A", translate: {0, 0}),
      button_spec("button B", translate: {50, 0})
    ],
    translate: {600, 0}
  )
]

@chan_q ...

@chan_f ...

@chan_db [
  Rotary.rotary_spec(0.50, id: {:chan, {:lf, :db}}, mode: :center, translate: {0, 0}),
  Rotary.rotary_spec(0.50, id: {:chan, {:lmf, :db}}, mode: :center, translate: {40, 0}),
  Rotary.rotary_spec(0.50, id: {:chan, {:hmf, :db}}, mode: :center, translate: {80, 0}),
  Rotary.rotary_spec(0.50, id: {:chan, {:hf, :db}}, mode: :center, translate: {120, 0})
]

@top_controls [
  group_spec(@chan_q, translate: {0, 110}),
  group_spec(@chan_f, translate: {0, 160}),
  group_spec(@chan_db, translate: {0, 350})
]

@top_groups [
  group_spec(@top_button_grid, translate: {0, 500}),
  group_spec(@top_controls, translate: {140, 0})
]

@graph Graph.build(font: :roboto, font_size: 16)
       |> add_specs_to_graph(@top_groups)
```

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [X] Check other PRs and make sure that the changes are not done yet.
- [X] The PR title is no longer than 64 characters.
