### PR TITLE
Document that the `Primitives.group` does not take a primitive

### DIFF
--- a/lib/scenic/primitives.ex
+++ b/lib/scenic/primitives.ex
@@ -503,6 +503,9 @@ defmodule Scenic.Primitives do
         |> text( "I'm in the Group" )
       end, translate: {40,200})
 
+  NOTE: Unlike other primitives, `group/3` currently only takes a graph and not
+  an existing group primitive.
+
   ### Styles
 
   Groups will accept all styles. They don't use the styles directly, but
@@ -524,7 +527,7 @@ defmodule Scenic.Primitives do
           options :: list
         ) :: Graph.t()
 
-  def group(graph_or_primitive, builder, opts \\ [])
+  def group(graph, builder, opts \\ [])
 
   def group(%Graph{} = graph, builder, opts) when is_function(builder, 1) do
     Primitive.Group.add_to_graph(graph, builder, opts)


### PR DESCRIPTION
Document that the `Primitives.group` does not take a primitive

## Motivation and Context

I didn't understand at first why I was getting a function clause error when passing in a primitive even though the documentation says that it is accepted. So I'm fixing the documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
