### PR TITLE
fix(TextAlign): Add missing comma in documentation

### DIFF
--- a/lib/scenic/primitive/style/text_align.ex
+++ b/lib/scenic/primitive/style/text_align.ex
@@ -10,7 +10,7 @@ defmodule Scenic.Primitive.Style.TextAlign do
   Example:
 
       graph
-      |> text( "Some Text" text_align: :center_middle )
+      |> text( "Some Text", text_align: :center_middle )
 
   ## Data
 


### PR DESCRIPTION
## Description

Simple, really: add a missing comma in the documentation for `TextAlign`.

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
