### PR TITLE
fix docs and add errors concerning custom fonts

### DIFF
--- a/guides/custom_fonts.md
+++ b/guides/custom_fonts.md
@@ -64,7 +64,6 @@ In your scene, you need to make load both the `\*.metrics` file into the `Scenic
 
 
 ```elixir
-@font_folder :code.priv_dir(:my_app) |> Path.join("/static/fonts")
 @custom_font_hash "0IXAWqFTtjn6MKSgQOzxUgxNKGrmyhqz1e2d90PVHck"
 @custom_metrics_path :code.priv_dir(:scenic_example)
            |> Path.join("/static/fonts/Roboto_Slab/RobotoSlab-Regular.ttf.metrics")
@@ -72,8 +71,12 @@ In your scene, you need to make load both the `\*.metrics` file into the `Scenic
 
 def init(_, _opts) do
   # load the custom font
-  Cache.Static.Font.load(@font_folder, @custom_font_hash)
-  Cache.Static.FontMetrics.load(@custom_metrics_path, @custom_metrics_hash)
+  font_folder = :code.priv_dir(:my_app) |> Path.join("/static/fonts")
+  custom_metrics_path = :code.priv_dir(:scenic_example)
+           |> Path.join("/static/fonts/Roboto_Slab/RobotoSlab-Regular.ttf.metrics")
+  
+  Cache.Static.Font.load(font_folder, @custom_font_hash)
+  Cache.Static.FontMetrics.load(custom_metrics_path, @custom_metrics_hash)
 
   # no need to put the graph into state as we won't be using it again
   {:ok, nil, push: @graph}

--- a/lib/scenic/cache/static/font.ex
+++ b/lib/scenic/cache/static/font.ex
@@ -6,6 +6,7 @@
 defmodule Scenic.Cache.Static.Font do
   use Scenic.Cache.Base, name: "font", static: true
   alias Scenic.Cache.Support
+  require Logger
 
   # import IEx
 
@@ -176,6 +177,7 @@ defmodule Scenic.Cache.Static.Font do
           {:ok, hash}
         else
           err ->
+            Logger.error("Could not load font at #{font_folder}: #{inspect(err)}")
             err
         end
     end

--- a/lib/scenic/cache/static/font_metrics.ex
+++ b/lib/scenic/cache/static/font_metrics.ex
@@ -6,6 +6,7 @@
 defmodule Scenic.Cache.Static.FontMetrics do
   use Scenic.Cache.Base, name: "font_metrics", static: true
   alias Scenic.Cache.Support
+  require Logger
 
   @moduledoc """
   In memory cache for static font_metrics assets.
@@ -225,7 +226,9 @@ defmodule Scenic.Cache.Static.FontMetrics do
              {:ok, metrics} <- FontMetrics.from_binary(data) do
           put_new(hash, metrics, opts[:scope])
         else
-          err -> err
+          err ->
+            Logger.error("Could not load font metrics at #{path}: #{inspect(err)}")
+            err
         end
     end
   end

--- a/test/scenic/cache/static/font_metrics_test.exs
+++ b/test/scenic/cache/static/font_metrics_test.exs
@@ -9,6 +9,7 @@ defmodule Scenic.Cache.Static.FontMetricsTest do
   alias Scenic.Cache.Base
   alias Scenic.Cache.Static
   alias Scenic.Cache.Support
+  import ExUnit.CaptureLog
 
   @base_path :code.priv_dir(:scenic)
              |> Path.join("static/font_metrics")
@@ -112,11 +113,15 @@ defmodule Scenic.Cache.Static.FontMetricsTest do
   end
 
   test "load passes through errors" do
-    assert Static.FontMetrics.load("wrong/path", @roboto_hash) ==
-             {:error, :enoent}
+    assert capture_log(fn ->
+             assert Static.FontMetrics.load("wrong/path", @roboto_hash) ==
+                      {:error, :enoent}
+           end) =~ "Could not load font metrics at"
 
-    assert Static.FontMetrics.load(@roboto_path, "bad_hash") ==
-             {:error, :hash_failure}
+    assert capture_log(fn ->
+             assert Static.FontMetrics.load(@roboto_path, "bad_hash") ==
+                      {:error, :hash_failure}
+           end) =~ "Could not load font metrics at"
   end
 
   # ============================================================================

--- a/test/scenic/cache/static/font_test.exs
+++ b/test/scenic/cache/static/font_test.exs
@@ -9,6 +9,7 @@ defmodule Scenic.Cache.Static.FontTest do
   alias Scenic.Cache.Base
   alias Scenic.Cache.Static.Font
   alias Scenic.Cache.Support
+  import ExUnit.CaptureLog
 
   @folder File.cwd!()
           |> Path.join("test/artifacts")
@@ -115,11 +116,15 @@ defmodule Scenic.Cache.Static.FontTest do
   end
 
   test "load passes through errors" do
-    assert Font.load("wrong/path", @hash) ==
-             {:error, :not_found}
+    assert capture_log(fn ->
+             assert Font.load("wrong/path", @hash) ==
+                      {:error, :not_found}
+           end) =~ "Could not load font at"
 
-    assert Font.load(@folder, "bad_hash") ==
-             {:error, :hash_failure}
+    assert capture_log(fn ->
+             assert Font.load(@folder, "bad_hash") ==
+                      {:error, :hash_failure}
+           end) =~ "Could not load font at"
   end
 
   # ============================================================================


### PR DESCRIPTION

## Description
The documentation example for loading custom fonts doesn't work when the code is booted under Nerves. The font path for loading must be computed at runtime and not during compilation. I also added some error logging which would have helped me get through this.

## Motivation and Context
I couldn't get custom fonts working when deployed on a Nerves device. I think the logging will help others with this and related issues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x ] Check other PRs and make sure that the changes are not done yet.
- [ x] The PR title is no longer than 64 characters.
