### PR TITLE
rename hover_primitve to hover_primitive

### DIFF
--- a/lib/scenic/primitive.ex
+++ b/lib/scenic/primitive.ex
@@ -347,7 +347,7 @@ defmodule Scenic.Primitive do
   Returns the primitive with the updated styles.
   """
   @spec put_styles(primitive :: Primitive.t(), styles :: map) :: Primitive.t()
-  def put_styles(primitve, styles)
+  def put_styles(primitive, styles)
   def put_styles(%Primitive{} = p, nil), do: Map.delete(p, :styles)
   def put_styles(%Primitive{} = p, s) when s == %{}, do: Map.delete(p, :styles)
 
@@ -454,7 +454,7 @@ defmodule Scenic.Primitive do
   Returns the primitive with the updated transforms.
   """
   @spec put_transforms(primitive :: Primitive.t(), transforms :: map) :: Primitive.t()
-  def put_transforms(primitve, transforms)
+  def put_transforms(primitive, transforms)
   def put_transforms(%Primitive{} = p, nil), do: Map.delete(p, :transforms)
   def put_transforms(%Primitive{} = p, t) when t == %{}, do: Map.delete(p, :transforms)
 

--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -463,7 +463,7 @@ defmodule Scenic.ViewPort do
       dynamic_root_pid: nil,
       root_config: nil,
       input_captures: %{},
-      hover_primitve: nil,
+      hover_primitive: nil,
       drivers: [],
       driver_registry: %{},
       supervisor: vp_supervisor,
@@ -512,7 +512,7 @@ defmodule Scenic.ViewPort do
     # prep state, which is mostly about resetting input
     state =
       state
-      |> Map.put(:hover_primitve, nil)
+      |> Map.put(:hover_primitive, nil)
       |> Map.put(:input_captures, %{})
 
     # fetch the dynamic supervisor

--- a/lib/scenic/view_port/input.ex
+++ b/lib/scenic/view_port/input.ex
@@ -499,9 +499,9 @@ defmodule Scenic.ViewPort.Input do
   # ============================================================================
   # regular input helper utilties
 
-  defp send_exit_message(%{hover_primitve: nil} = state), do: state
+  defp send_exit_message(%{hover_primitive: nil} = state), do: state
 
-  defp send_exit_message(%{hover_primitve: {uid, graph_key}} = state) do
+  defp send_exit_message(%{hover_primitive: {uid, graph_key}} = state) do
     Scene.cast(
       graph_key,
       {
@@ -511,13 +511,13 @@ defmodule Scenic.ViewPort.Input do
       }
     )
 
-    %{state | hover_primitve: nil}
+    %{state | hover_primitive: nil}
   end
 
-  defp send_enter_message(uid, id, graph_key, %{hover_primitve: hover_primitve} = state) do
-    # first, send the previous hover_primitve an exit message
+  defp send_enter_message(uid, id, graph_key, %{hover_primitive: hover_primitive} = state) do
+    # first, send the previous hover_primitive an exit message
     state =
-      case hover_primitve do
+      case hover_primitive do
         nil ->
           # no previous hover_primitive set. do not send an exit message
           state
@@ -531,9 +531,9 @@ defmodule Scenic.ViewPort.Input do
           send_exit_message(state)
       end
 
-    # send the new hover_primitve an enter message
+    # send the new hover_primitive an enter message
     state =
-      case state.hover_primitve do
+      case state.hover_primitive do
         nil ->
           # yes. setting a new one. send it.
           Scene.cast(
@@ -545,7 +545,7 @@ defmodule Scenic.ViewPort.Input do
             }
           )
 
-          %{state | hover_primitve: {uid, graph_key}}
+          %{state | hover_primitive: {uid, graph_key}}
 
         _ ->
           # not setting a new one. do nothing.

--- a/test/scenic/view_port/input_test.exs
+++ b/test/scenic/view_port/input_test.exs
@@ -269,7 +269,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{},
           max_depth: 10,
-          hover_primitve: nil
+          hover_primitive: nil
         }
       )
 
@@ -289,7 +289,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{},
           max_depth: 10,
-          hover_primitve: nil
+          hover_primitive: nil
         }
       )
 
@@ -316,7 +316,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{},
           max_depth: 10,
-          hover_primitve: nil
+          hover_primitive: nil
         }
       )
 
@@ -342,7 +342,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{},
           max_depth: 10,
-          hover_primitve: {1, graph_key}
+          hover_primitive: {1, graph_key}
         }
       )
 
@@ -368,7 +368,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{},
           max_depth: 10,
-          hover_primitve: {1, graph_key}
+          hover_primitive: {1, graph_key}
         }
       )
 
@@ -391,7 +391,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{},
           max_depth: 10,
-          hover_primitve: {1, graph_key}
+          hover_primitive: {1, graph_key}
         }
       )
 
@@ -645,7 +645,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{cursor_pos: context},
           max_depth: 10,
-          hover_primitve: nil
+          hover_primitive: nil
         }
       )
 
@@ -670,7 +670,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{cursor_pos: context},
           max_depth: 10,
-          hover_primitve: nil
+          hover_primitive: nil
         }
       )
 
@@ -695,7 +695,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{cursor_pos: context},
           max_depth: 10,
-          hover_primitve: nil
+          hover_primitive: nil
         }
       )
 
@@ -723,7 +723,7 @@ defmodule Scenic.ViewPort.InputTest do
           root_graph_key: graph_key,
           input_captures: %{cursor_pos: context},
           max_depth: 10,
-          hover_primitve: {1, graph_key1}
+          hover_primitive: {1, graph_key1}
         }
       )
 


### PR DESCRIPTION
## Description

hover_primitive is mispelled. I hope this isn't a breaking change and thought I might as well submit it as a PR.

## Motivation and Context

Just a typo fix.

## Types of changes


- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
