### PR TITLE
Fixed issue #184 component name option.

### DIFF
--- a/lib/scenic/primitive.ex
+++ b/lib/scenic/primitive.ex
@@ -36,7 +36,7 @@ defmodule Scenic.Primitive do
   versions of the drivers.
 
   * [`Arc`](Scenic.Primitive.Arc.html) draws an arc. This would be a line cut out of a part of the edge of a circle. If you want a shape that looks like a piece of pie, then you should use the [`Sector`](Scenic.Primitive.Sector.html).
-  * [`Circle`](Scenic.Primitive.Circle.html) draws a circle. 
+  * [`Circle`](Scenic.Primitive.Circle.html) draws a circle.
   * [`Ellipse`](Scenic.Primitive.Ellipse.html) draws an ellipse.
   * [`Group`](Scenic.Primitive.Group.html) doesn't draw anything. Instead, it creates a node in the graph that you can insert more primitives into. Any styles or transforms you apply to the Group are inherited by all the primitives below it.
   * [`Line`](Scenic.Primitive.Line.html) draws a line.
@@ -74,6 +74,7 @@ defmodule Scenic.Primitive do
   @not_styles [
     :module,
     :id,
+    :name,
     :parent_uid,
     :builder,
     :data,
@@ -88,7 +89,7 @@ defmodule Scenic.Primitive do
 
   @transform_types [:pin, :rotate, :matrix, :scale, :translate]
 
-  @standard_options [:id]
+  @standard_options [:id, :name]
 
   # note: the following fields are all optional on a primitive.
   # :id, :tags, :event_filter, :state, :styles, :transforms
@@ -239,8 +240,8 @@ defmodule Scenic.Primitive do
 
     # enumerate and apply each of the standard opts
     Enum.reduce(opts, p, fn
-      {:id, v}, p ->
-        Map.put(p, :id, v)
+      {opt, v}, p ->
+        Map.put(p, opt, v)
     end)
   end
 

--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -1384,11 +1384,17 @@ defmodule Scenic.Scene do
 
           # prepare the startup options to send to the new scene
           id = Map.get(raw_graph.primitives[uid], :id)
+          name = Map.get(raw_graph.primitives[uid], :name)
 
           init_opts =
             case viewport do
               nil -> [styles: styles, id: id]
               vp -> [viewport: vp, styles: styles, id: id]
+            end
+          init_opts =
+            case name do
+              nil -> init_opts
+              value -> [{:name, value} | init_opts]
             end
 
           # start the dynamic scene


### PR DESCRIPTION
Implemented enhancement #184 component name option.

## Description

In `primitive.ex` added `:name` to `@not_styles` and `@standard_options` and changed `apply_standard_options/2` to pass the name option into the primitive.

In `scene.ex` changed `internal_push_graph` to add the name option to `init_opts`.

## Motivation and Context
[Issue #184 component name option](https://github.com/boydm/scenic/issues/184)

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [X] Check other PRs and make sure that the changes are not done yet.
- [X] The PR title is no longer than 64 characters.
