### PR TITLE
Fix a few code snippets in the guides

### DIFF
--- a/guides/overview_graph.md
+++ b/guides/overview_graph.md
@@ -11,7 +11,7 @@ one thing. When multiple primitives are put together, almost any standard UI can
 For example, the graph below shows the words "Hello World" around them.
 
     @graph Graph.build(font: :roboto, font_size: 24)
-      |> text("Hello World", text_align: center, translate: {300, 300})
+      |> text("Hello World", text_align: :center, translate: {300, 300})
       |> circle(100, stroke: {2, :green}, translate: {300, 300})
 
 In the example above, the first line creates a new graph and assigns two font styles to its root. The next two lines form a pipeline that adds primitives to the root

--- a/guides/overview_scene.md
+++ b/guides/overview_scene.md
@@ -52,7 +52,7 @@ whose helper function is imported from the `Scenic.Components` module.
 
         @graph Graph.build()
           |> text("Hello World", font_size: 22, translate: {20, 80})
-          |> button({"Do Something", :btn_something}, translate: {20, 180})
+          |> button("Do Something", translate: {20, 180})
 
         def init( _scene_args, _options ) do
           {:ok, @graph, push: @graph}


### PR DESCRIPTION
I made two changes in these commits. First, in the `MyApp.Scene.Example` snippet, I replaced a tuple as the first parameter to `button` with a string. Second, in the `"Hello World"` graph example, I fixed the `:center` atom.

## Description

The first parameter to `button` in the example was `{"Do Something", :btn_something}`. This would not compile, so I replaced this parameter with `"Do Something"`, which allows it to compile.

The other issue was that the text in the Graph Overview was given `text_align: center` as a parameter instead of `text_align: :center`, which prevented the snippet from executing.

## Motivation and Context

I ran into these when reading through the docs and experimenting with the examples.

## Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [X] Check other PRs and make sure that the changes are not done yet.
- [X] The PR title is no longer than 64 characters.
