### PR TITLE
Tell git not to mangle line endings on test data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+
+# Tests using this test data assert on the hashes so checking them out with
+# Windows line endings causes test failures.
+test/test_data/*            text eol=lf
+test/artifacts/sample_file  text eol=lf
+test/artifacts/text_file    text eol=lf


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

Several checked in test files were text files and tests had been asserting their hash. Problem is, on Windows, Git had manipulated the line endings of these files. So I added a `.gitattributes` file to stop those specific files being manipulated.

This fixes the only 12 test failures I had on Windows 10, so now:

    Finished in 6.4 seconds
    8 doctests, 931 tests, 0 failures


## Motivation and Context

I generally like to run the test suite and get no failures before touching anything.

Jokes aside, I was curious as to how much would even pass on Windows and was pleasantly surprised that everything seems to.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
