### PR TITLE
Allow `name:` keyword param in call to `use Scenic.{Scene,Component}`

### DIFF
--- a/lib/scenic/component.ex
+++ b/lib/scenic/component.ex
@@ -49,6 +49,19 @@ defmodule Scenic.Component do
   should do some basic validation that the data being set up is valid, then provide
   feedback if it isn't.
 
+  ## Optional: Named Component
+
+  Whether you override one or more message handlers, like `handle_info/2`,
+  you might want to use registered name as
+  [`Process.dest()`](https://hexdocs.pm/elixir/Process.html?#t:dest/0).
+  For this to be possible, you might pass `name:` keyword argument in a call
+  to `use Scenic.Component`.
+
+      use Scenic.Component, name: __MODULE__
+
+  Once passed, it limits the usage of this particular component to
+  a single instance, because two processes cannot be registered under the same name.
+
   ## Optional: No Children
 
   There is an optimization you can use. If you know for certain that your component

--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -109,7 +109,7 @@ defmodule Scenic.Scene do
   immediate control. You update that graph by calling `push_graph`
   again.
 
-  **Note: ** The use of `push_graph` when returning from a scene update 
+  **Note: ** The use of `push_graph` when returning from a scene update
   has been deprecated. The use of `push: graph` in the return value is preferred.
 
   This does mean you could maintain two separate graphs
@@ -664,6 +664,12 @@ defmodule Scenic.Scene do
       # child spec that really starts up scene, with this module as an option
       @doc false
       def child_spec({args, opts}) when is_list(opts) do
+        opts =
+          case unquote(using_opts)[:name] do
+            mod when is_atom(mod) -> Keyword.put_new(opts, :name, mod)
+            _ -> opts
+          end
+
         %{
           id: make_ref(),
           start: {Scenic.Scene, :start_link, [__MODULE__, args, opts]},

--- a/test/scenic/component/custom_message_test.exs
+++ b/test/scenic/component/custom_message_test.exs
@@ -1,0 +1,53 @@
+defmodule Scenic.Component.CustomMessageTest do
+  use ExUnit.Case
+
+  setup do
+    ast =
+      quote do
+        use Scenic.Component, name: C
+
+        @graph Scenic.Graph.build()
+
+        @impl Scenic.Scene
+        def handle_info({:ping, pid}, state) do
+          send(pid, :pong)
+          {:noreply, state}
+        end
+
+        @impl Scenic.Scene
+        def handle_info({:DOWN, _, :process, _, _}, state),
+          do: {:noreply, state}
+
+        @impl Scenic.Scene
+        def init(_args, _opts \\ []) do
+          graph = @graph
+
+          state = %{
+            graph: graph
+          }
+
+          {:ok, state, push: graph}
+        end
+
+        @impl Scenic.Component
+        def verify(data), do: {:ok, data}
+      end
+
+    {:module, component, _, _} = Module.create(C, ast, Macro.Env.location(__ENV__))
+
+    on_exit(fn ->
+      :code.purge(C)
+      :code.delete(C)
+    end)
+
+    [component: component]
+  end
+
+  test "send message to named component", %{component: component} do
+    {:ok, sup} = Supervisor.start_link([{C, {[], []}}], strategy: :one_for_one)
+
+    send(component, {:ping, self()})
+    assert_receive(:pong, 200)
+    Supervisor.stop(sup)
+  end
+end


### PR DESCRIPTION
## Description

This PR allows creating a named process when there is only one instance of the component to simplify sending messages to this component when one of `handle_info/2`, `handle_cast/2` or `handle_call/3` is implemented.

It is 100% backward-compatible change.

## Motivation and Context

Inspired by this question os SO: https://stackoverflow.com/questions/64628987/how-to-send-a-message-from-one-scene-to-another-using-scenic

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
