### PR TITLE
Fixed a non-critical bug with is_atom(kw[:foo]) == true

### DIFF
--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -665,7 +665,8 @@ defmodule Scenic.Scene do
       @doc false
       def child_spec({args, opts}) when is_list(opts) do
         opts =
-          case Keyword.get(unquote(using_opts), :name, "unset") do
+          case unquote(using_opts)[:name] do
+            nil -> opts
             mod when is_atom(mod) -> Keyword.put_new(opts, :name, mod)
             _ -> opts
           end

--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -665,7 +665,7 @@ defmodule Scenic.Scene do
       @doc false
       def child_spec({args, opts}) when is_list(opts) do
         opts =
-          case unquote(using_opts)[:name] do
+          case Keyword.get(unquote(using_opts), :name, "unset") do
             mod when is_atom(mod) -> Keyword.put_new(opts, :name, mod)
             _ -> opts
           end


### PR DESCRIPTION
Follow-up of #201 :: bug fix.

## Description

In #201 that I had provided and you have merged, there was a non-critical bug.

Checking `opts[:name]` for being an `atom` is stupid, because when `opts` has no key `:name`, it returns `nil` which is apparently an atom. This PR fixes this by using `Keyword.get/3` instead, with the default value being a binary.

It probably did not bring any actual harm, because the value is being checked for not `nil` down the call stack, but it’s extremely inaccurate. Sorry about that.

## Motivation and Context

Context: #201. Motivation: make the codebase better.

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
