### PR TITLE
Fix Graph.modify/3 examples

### DIFF
--- a/lib/scenic/graph.ex
+++ b/lib/scenic/graph.ex
@@ -762,9 +762,9 @@ defmodule Scenic.Graph do
   Examples:
 
       graph
-      |> Graph.modify( :explicit_id, &text("Updated Text 1") )
-      |> Graph.modify( {:id, 123}, &text("Updated Text 2") )
-      |> Graph.modify( &match?({:id,_},&1), &text("Updated Text 3") )
+      |> Graph.modify( :explicit_id, &text(&1, "Updated Text 1") )
+      |> Graph.modify( {:id, 123}, &text(&1, "Updated Text 2") )
+      |> Graph.modify( &match?({:id,_},&1), &text(&1, "Updated Text 3") )
   """
 
   @spec modify(


### PR DESCRIPTION
## Description

Update the documentation for `Graph.modify/3` to fix the examples, which had:

```ex
|> Graph.modify( :explicit_id, &text("Updated Text 1") )
```

While it looks that should be:

```ex
|> Graph.modify( :explicit_id, &text(&1, "Updated Text 1") )
```

## Motivation and Context

The example code doesn't work.

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.