### PR TITLE
Fix Texture clear Nifs

### DIFF
--- a/c_src/texture.c
+++ b/c_src/texture.c
@@ -343,8 +343,7 @@ nif_clear_ga(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   if ( !enif_get_uint(env, argv[2], &a) )      {return enif_make_badarg(env);}  
 
   // clear the pixels
-  size = pixels.size / 2;
-  for( unsigned int i = 0; i < size; i += 2) {
+  for( unsigned int i = 0; i < pixels.size; i += 2) {
     pixels.data[i] = g;
     pixels.data[i+1] = a;
   }
@@ -368,8 +367,7 @@ nif_clear_rgb(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   if ( !enif_get_uint(env, argv[3], &b) )      {return enif_make_badarg(env);}
 
   // clear the pixels
-  size = pixels.size / 3;
-  for( unsigned int i = 0; i < size; i += 3) {
+  for( unsigned int i = 0; i < pixels.size; i += 3) {
     pixels.data[i] = r;
     pixels.data[i+1] = g;
     pixels.data[i+2] = b;
@@ -396,8 +394,7 @@ nif_clear_rgba(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   if ( !enif_get_uint(env, argv[4], &a) )      {return enif_make_badarg(env);}
 
   // clear the pixels
-  size = pixels.size / 4;
-  for( unsigned int i = 0; i < size; i += 4) {
+  for( unsigned int i = 0; i < pixels.size; i += 4) {
     pixels.data[i] = r;
     pixels.data[i+1] = g;
     pixels.data[i+2] = b;

--- a/c_src/texture.c
+++ b/c_src/texture.c
@@ -333,7 +333,6 @@ nif_clear_g(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 static ERL_NIF_TERM
 nif_clear_ga(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   ErlNifBinary  pixels;
-  unsigned int  size;
   unsigned int  g;
   unsigned int  a;
 
@@ -355,7 +354,6 @@ nif_clear_ga(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 static ERL_NIF_TERM
 nif_clear_rgb(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   ErlNifBinary  pixels;
-  unsigned int  size;
   unsigned int  r;
   unsigned int  g;
   unsigned int  b;
@@ -380,7 +378,6 @@ nif_clear_rgb(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 static ERL_NIF_TERM
 nif_clear_rgba(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   ErlNifBinary  pixels;
-  unsigned int  size;
   unsigned int  r;
   unsigned int  g;
   unsigned int  b;

--- a/test/utilities/texture_test.exs
+++ b/test/utilities/texture_test.exs
@@ -255,6 +255,7 @@ defmodule Scenic.Utilities.TextureTest do
     tex = Texture.clear!(tex, 4)
     assert Texture.get(tex, 1, 1) == 4
     assert Texture.get(tex, 1, 2) == 4
+    assert Texture.get(tex, 10, 12) == 4
   end
 
   test "clear! works with g textures uses black by default" do
@@ -262,14 +263,17 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:g, @width, @height)
       |> Texture.put!(1, 1, 7)
       |> Texture.put!(1, 2, 9)
+      |> Texture.put!(10, 12, 11)
 
     assert Texture.get(tex, 1, 1) == 7
     assert Texture.get(tex, 1, 2) == 9
+    assert Texture.get(tex, 10, 12) == 11
     assert Texture.get(tex, 1, 3) == 0
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == 0
     assert Texture.get(tex, 1, 2) == 0
+    assert Texture.get(tex, 10, 12) == 0
     assert Texture.get(tex, 1, 3) == 0
   end
 
@@ -278,14 +282,17 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:g, @width, @height, clear: :dark_khaki)
       |> Texture.put!(1, 1, 7)
       |> Texture.put!(1, 2, 9)
+      |> Texture.put!(10, 12, 11)
 
     assert Texture.get(tex, 1, 1) == 7
     assert Texture.get(tex, 1, 2) == 9
+    assert Texture.get(tex, 10, 12) == 11
     assert Texture.get(tex, 1, 3) == 159
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == 159
     assert Texture.get(tex, 1, 2) == 159
+    assert Texture.get(tex, 10, 12) == 159
     assert Texture.get(tex, 1, 3) == 159
   end
 
@@ -293,10 +300,12 @@ defmodule Scenic.Utilities.TextureTest do
     {:ok, tex} = Texture.build(:ga, @width, @height, clear: {3, 7})
     assert Texture.get(tex, 1, 1) == {3, 7}
     assert Texture.get(tex, 1, 2) == {3, 7}
+    assert Texture.get(tex, 10, 12) == {3, 7}
 
     tex = Texture.clear!(tex, {4, 8})
     assert Texture.get(tex, 1, 1) == {4, 8}
     assert Texture.get(tex, 1, 2) == {4, 8}
+    assert Texture.get(tex, 10, 12) == {4, 8}
   end
 
   test "clear! works with ga textures uses black by default" do
@@ -304,14 +313,17 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:ga, @width, @height)
       |> Texture.put!(1, 1, {3, 7})
       |> Texture.put!(1, 2, {4, 8})
+      |> Texture.put!(10, 12, {6, 9})
 
     assert Texture.get(tex, 1, 1) == {3, 7}
     assert Texture.get(tex, 1, 2) == {4, 8}
+    assert Texture.get(tex, 10, 12) == {6, 9}
     assert Texture.get(tex, 1, 3) == {0, 0xFF}
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == {0, 0xFF}
     assert Texture.get(tex, 1, 2) == {0, 0xFF}
+    assert Texture.get(tex, 10, 12) == {0, 0xFF}
   end
 
   test "clear! works with ga textures uses texture clear by default" do
@@ -319,24 +331,29 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:ga, @width, @height, clear: :dark_khaki)
       |> Texture.put!(1, 1, {3, 7})
       |> Texture.put!(1, 2, {4, 8})
+      |> Texture.put!(10, 12, {6, 9})
 
     assert Texture.get(tex, 1, 1) == {3, 7}
     assert Texture.get(tex, 1, 2) == {4, 8}
+    assert Texture.get(tex, 10, 12) == {6, 9}
     assert Texture.get(tex, 1, 3) == {159, 0xFF}
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == {159, 0xFF}
     assert Texture.get(tex, 1, 2) == {159, 0xFF}
+    assert Texture.get(tex, 10, 12) == {159, 0xFF}
   end
 
   test "clear! works with rgb textures" do
     {:ok, tex} = Texture.build(:rgb, @width, @height, clear: {3, 7, 11})
     assert Texture.get(tex, 1, 1) == {3, 7, 11}
     assert Texture.get(tex, 1, 2) == {3, 7, 11}
+    assert Texture.get(tex, 10, 12) == {3, 7, 11}
 
     tex = Texture.clear!(tex, {4, 8, 12})
     assert Texture.get(tex, 1, 1) == {4, 8, 12}
     assert Texture.get(tex, 1, 2) == {4, 8, 12}
+    assert Texture.get(tex, 10, 12) == {4, 8, 12}
   end
 
   test "clear! works with rgb textures uses black by default" do
@@ -344,14 +361,17 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:rgb, @width, @height)
       |> Texture.put!(1, 1, {3, 7, 11})
       |> Texture.put!(1, 2, {4, 8, 12})
+      |> Texture.put!(10, 12, {6, 9, 11})
 
     assert Texture.get(tex, 1, 1) == {3, 7, 11}
     assert Texture.get(tex, 1, 2) == {4, 8, 12}
+    assert Texture.get(tex, 10, 12) == {6, 9, 11}
     assert Texture.get(tex, 1, 3) == {0, 0, 0}
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == {0, 0, 0}
     assert Texture.get(tex, 1, 2) == {0, 0, 0}
+    assert Texture.get(tex, 10, 12) == {0, 0, 0}
     assert Texture.get(tex, 1, 3) == {0, 0, 0}
   end
 
@@ -360,14 +380,17 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:rgb, @width, @height, clear: :dark_khaki)
       |> Texture.put!(1, 1, {3, 7, 11})
       |> Texture.put!(1, 2, {4, 8, 12})
+      |> Texture.put!(10, 12, {6, 9, 11})
 
     assert Texture.get(tex, 1, 1) == {3, 7, 11}
     assert Texture.get(tex, 1, 2) == {4, 8, 12}
+    assert Texture.get(tex, 10, 12) == {6, 9, 11}
     assert Texture.get(tex, 1, 3) == {189, 183, 107}
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == {189, 183, 107}
     assert Texture.get(tex, 1, 2) == {189, 183, 107}
+    assert Texture.get(tex, 10, 12) == {189, 183, 107}
     assert Texture.get(tex, 1, 3) == {189, 183, 107}
   end
 
@@ -375,10 +398,12 @@ defmodule Scenic.Utilities.TextureTest do
     {:ok, tex} = Texture.build(:rgba, @width, @height, clear: {3, 7, 11, 13})
     assert Texture.get(tex, 1, 1) == {3, 7, 11, 13}
     assert Texture.get(tex, 1, 2) == {3, 7, 11, 13}
+    assert Texture.get(tex, 10, 12) == {3, 7, 11, 13}
 
     tex = Texture.clear!(tex, {4, 8, 12, 14})
     assert Texture.get(tex, 1, 1) == {4, 8, 12, 14}
     assert Texture.get(tex, 1, 2) == {4, 8, 12, 14}
+    assert Texture.get(tex, 10, 12) == {4, 8, 12, 14}
   end
 
   test "clear! works with rgba textures uses black by default" do
@@ -386,14 +411,17 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:rgba, @width, @height)
       |> Texture.put!(1, 1, {3, 7, 11, 13})
       |> Texture.put!(1, 2, {4, 8, 12, 14})
+      |> Texture.put!(10, 12, {6, 9, 11, 13})
 
     assert Texture.get(tex, 1, 1) == {3, 7, 11, 13}
     assert Texture.get(tex, 1, 2) == {4, 8, 12, 14}
+    assert Texture.get(tex, 10, 12) == {6, 9, 11, 13}
     assert Texture.get(tex, 1, 3) == {0, 0, 0, 0xFF}
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == {0, 0, 0, 0xFF}
     assert Texture.get(tex, 1, 2) == {0, 0, 0, 0xFF}
+    assert Texture.get(tex, 10, 12) == {0, 0, 0, 0xFF}
     assert Texture.get(tex, 1, 3) == {0, 0, 0, 0xFF}
   end
 
@@ -402,14 +430,17 @@ defmodule Scenic.Utilities.TextureTest do
       Texture.build!(:rgba, @width, @height, clear: :dark_khaki)
       |> Texture.put!(1, 1, {3, 7, 11, 13})
       |> Texture.put!(1, 2, {4, 8, 12, 14})
+      |> Texture.put!(10, 12, {6, 9, 11, 13})
 
     assert Texture.get(tex, 1, 1) == {3, 7, 11, 13}
     assert Texture.get(tex, 1, 2) == {4, 8, 12, 14}
+    assert Texture.get(tex, 10, 12) == {6, 9, 11, 13}
     assert Texture.get(tex, 1, 3) == {189, 183, 107, 255}
 
     tex = Texture.clear!(tex)
     assert Texture.get(tex, 1, 1) == {189, 183, 107, 255}
     assert Texture.get(tex, 1, 2) == {189, 183, 107, 255}
+    assert Texture.get(tex, 10, 12) == {189, 183, 107, 255}
     assert Texture.get(tex, 1, 3) == {189, 183, 107, 255}
   end
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

The `nif_clear_*` functions only do a partial clear. In case of `rgb`, only the top third of the texture gets cleared.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #215

I have added tests for the last pixel (`@width - 1, @height - 1)` for all texture types.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
