### PR TITLE
Stricter font_metrics requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Scenic.Mixfile do
 
   defp deps do
     [
-      {:font_metrics, "~> 0.3"},
+      {:font_metrics, "~> 0.3.0"},
       {:elixir_make, "~> 0.6", runtime: false},
 
       # Tools


### PR DESCRIPTION
## Description

Scenic uses `FontMetrics.from_binary/1` which is no longer there in v0.5.x.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
