### PR TITLE
Scale shortcut now properly expands

### DIFF
--- a/lib/scenic/primitive/transform/transform.ex
+++ b/lib/scenic/primitive/transform/transform.ex
@@ -56,14 +56,16 @@ defmodule Scenic.Primitive.Transform do
   }
 
   @opts_schema [
+    # Note: Due to https://github.com/dashbitco/nimble_options/issues/68 any
+    # `:rename_to` entries need to come before the keys that they are renaming
+    t: [rename_to: :translate],
+    s: [rename_to: :scale],
+    r: [rename_to: :rotate],
     translate: [type: {:custom, Transform.Translate, :validate, []}],
     scale: [type: {:custom, Transform.Scale, :validate, []}],
     rotate: [type: {:custom, Transform.Rotate, :validate, []}],
     pin: [type: {:custom, Transform.Pin, :validate, []}],
-    matrix: [type: {:custom, Transform.Matrix, :validate, []}],
-    t: [rename_to: :translate],
-    s: [rename_to: :scale],
-    r: [rename_to: :rotate]
+    matrix: [type: {:custom, Transform.Matrix, :validate, []}]
   ]
 
   @primitive_transforms [

--- a/test/scenic/primitive/transform_test.exs
+++ b/test/scenic/primitive/transform_test.exs
@@ -41,6 +41,13 @@ defmodule Scenic.Primitive.TransformTest do
     assert Transform.combine(only_pin) == nil
   end
 
+  test "scale shortcut gets properly expanded" do
+    tx = [s: 0.6]
+
+    assert NimbleOptions.validate(tx, Transform.opts_schema()) ==
+             {:ok, [s: 0.6, scale: {0.6, 0.6}]}
+  end
+
   test "combine calculates the local matrix in the right order" do
     # first calc all the matrices
     mx_pin = Matrix.build_translation(@pin)


### PR DESCRIPTION
## Description

Previously if you created a component like this:
```elixir
|> ScenicContrib.IconComponent.add_to_graph(
  [
    icon: PianoUi.EmptySongIcon,
    width: 500,
    height: 500
  ],
  id: :empty_icon,
  t: {10, 160},
  p: {10, 117},
  s: 0.6
)
```

It would fail to render with a `CaseCauseError`:
> ** (CaseClauseError) no case clause matching: %{s: 0.6, scale: 0.6, translate: {10, 160}}
>    (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:439: Scenic.ViewPort.GraphCompiler.zero_pin/2
>    (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:129: Scenic.ViewPort.GraphCompiler.do_compile_primitive/4
>    (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:116: Scenic.ViewPort.GraphCompiler.compile_primitive/4

This happens because of a bug in NimbleOptions: https://github.com/dashbitco/nimble_options/issues/68
which causes the scale of `0.6` to not be expanded to `{0.6, 0.6}`. This PR works around that bug.

## Motivation and Context

This fixes a bug

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
