### PR TITLE
Improve scene termination error

### DIFF
--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -869,9 +869,9 @@ defmodule Scenic.Scene do
     module.terminate(reason, scene)
   end
 
-  # def terminate( _reason, _state ) do
-  #   nil
-  # end
+  def terminate( _reason, _state ) do
+    nil
+  end
 
   # ============================================================================
   # handle_continue


### PR DESCRIPTION
## Description

Without this change a scene that terminates due to an unhandled error gives a hard-to-read error like:

> 16:31:01.448 [error] GenServer #PID<0.1006.0> terminating
> ** (FunctionClauseError) no function clause matching in Scenic.Scene.terminate/2
>     (scenic 0.11.0) lib/scenic/scene.ex:868: Scenic.Scene.terminate({{:case_clause, %{s: 0.6, scale: 0.6, t: {10, 160}, translate: {10, 160}}}, [{Scenic.ViewPort.GraphCompiler, :zero_pin, 2, [file: 'lib/scenic/view_port/graph_compiler.ex', line: 429]}, {Scenic.ViewPort.GraphCompiler, :do_compile_primitive, 4, [file: 'lib/scenic/view_port/graph_compiler.ex', line: 129]}, {Scenic.ViewPort.GraphCompiler, :compile_primitive, 4, [file: 'lib/scenic/view_port/graph_compiler.ex', line: 116]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 2356]}, {Scenic.ViewPort.GraphCompiler, :do_primitive, 3, [file: 'lib/scenic/view_port/graph_compiler.ex', line: 220]}, {Scenic.ViewPort.GraphCompiler, :do_compile_primitive, 4, [file: 'lib/scenic/view_port/graph_compiler.ex', line: 134]}, {Scenic.ViewPort.GraphCompiler, :compile_primitive, 4, [file: 'lib/scenic/view_port/graph_compiler.ex', line: 116]}, {Scenic.ViewPort.GraphCompiler, :compile, 2, [file: 'lib/scenic/view_port/graph_compiler.ex', line: 75]}, {Scenic.ViewPort, :put_graph, 4, [file: 'lib/scenic/view_port.ex', line: 370]}, {Scenic.Scene, :push_graph, 3, [file: 'lib/scenic/scene.ex', line: 555]}, {PianoUi.Scene.Splash, :init, 3, [file: 'lib/piano_ui/scene/splash.ex', line: 103]}, {Scenic.Scene, :handle_continue, 2, [file: 'lib/scenic/scene.ex', line: 925]}, {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 689]}, {:gen_server, :loop, 7, [file: 'gen_server.erl', line: 431]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}, nil)
>     (stdlib 3.14) gen_server.erl:727: :gen_server.try_terminate/3
>     (stdlib 3.14) gen_server.erl:912: :gen_server.terminate/10
>     (stdlib 3.14) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
> Last message: {:continue, {:_init, [supervisor: #PID<0.1000.0>, stop_pid: #PID<0.1000.0>, child_supervisor: nil, name: :_root_, module: PianoUi.Scene.Splash, parent: #PID<0.969.0>, param: [], viewport: %Scenic.ViewPort{name: :main_viewport, name_table: #Reference<0.3369751254.288489473.22276>, pid: #PID<0.969.0>, script_table: #Reference<0.3369751254.288489473.22277>, size: {800, 480}}, root_sup: #PID<0.971.0>, opts: [theme: :dark]]}}
> State: nil

With this change the error looks like:
> 16:25:54.934 [error] GenServer #PID<0.1006.0> terminating
> ** (CaseClauseError) no case clause matching: %{s: 0.6, scale: 0.6, t: {10, 160}, translate: {10, 160}}
>     (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:429: Scenic.ViewPort.GraphCompiler.zero_pin/2
>     (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:129: Scenic.ViewPort.GraphCompiler.do_compile_primitive/4
>     (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:116: Scenic.ViewPort.GraphCompiler.compile_primitive/4
>     (elixir 1.12.1) lib/enum.ex:2356: Enum."-reduce/3-lists^foldl/2-0-"/3
>     (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:220: Scenic.ViewPort.GraphCompiler.do_primitive/3
>     (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:134: Scenic.ViewPort.GraphCompiler.do_compile_primitive/4
>     (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:116: Scenic.ViewPort.GraphCompiler.compile_primitive/4
>     (scenic 0.11.0) lib/scenic/view_port/graph_compiler.ex:75: Scenic.ViewPort.GraphCompiler.compile/2
>     (scenic 0.11.0) lib/scenic/view_port.ex:370: Scenic.ViewPort.put_graph/4
>     (scenic 0.11.0) lib/scenic/scene.ex:555: Scenic.Scene.push_graph/3
>     (piano_ui 0.1.0) lib/piano_ui/scene/splash.ex:103: PianoUi.Scene.Splash.init/3
>     (scenic 0.11.0) lib/scenic/scene.ex:931: Scenic.Scene.handle_continue/2
>     (stdlib 3.14) gen_server.erl:689: :gen_server.try_dispatch/4
>     (stdlib 3.14) gen_server.erl:431: :gen_server.loop/7
>     (stdlib 3.14) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
> Last message: {:continue, {:_init, [supervisor: #PID<0.1000.0>, stop_pid: #PID<0.1000.0>, child_supervisor: nil, name: :_root_, module: PianoUi.Scene.Splash, parent: #PID<0.969.0>, param: [], viewport: %Scenic.ViewPort{name: :main_viewport, name_table: #Reference<0.718893949.4045012997.90723>, pid: #PID<0.969.0>, script_table: #Reference<0.718893949.4045012997.90724>, size: {800, 480}}, root_sup: #PID<0.971.0>, opts: [theme: :dark]]}}
> State: nil

## Motivation and Context

This makes it easier to debug a scene that is failing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
