### PR TITLE
Fix Scenic.Assets.Stream.Image.from_image typespec

### DIFF
--- a/lib/scenic/assets/stream/image.ex
+++ b/lib/scenic/assets/stream/image.ex
@@ -44,7 +44,7 @@ defmodule Scenic.Assets.Stream.Image do
   The supplied binary must be a valid jpeg or png format. If it is either invalid or an
   unrecognized format, this will return `{:error, :invalid}`
   """
-  @spec from_binary(bin :: binary) :: t() | {:error, :invalid}
+  @spec from_binary(bin :: binary) :: {:ok, t()} | {:error, :invalid}
   def from_binary(bin) when is_binary(bin) do
     case ExImageInfo.info(bin) do
       {mime, width, height, _type} -> {:ok, {__MODULE__, {width, height, mime}, bin}}


### PR DESCRIPTION
## Description

Fix `Scenic.Assets.Stream.Image.from_image/1` typespec

## Motivation and Context

Fixes incorrect dialyzer warnings in downstream projects

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
