### PR TITLE
Detect incorrect argument to set_root

### DIFF
--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -420,6 +420,10 @@ defmodule Scenic.ViewPort do
     GenServer.call(pid, {:set_root, scene, args})
   end
 
+  def set_root(_, %Scene{} = scene, _) do
+    raise "You must pass the module that represents the scene you want to switch to here, not a `%Scenic.Scene{}`"
+  end
+
   # --------------------------------------------------------
   @doc """
   Send raw input to a viewport.


### PR DESCRIPTION
## Description

Helps users when they provide an incorrect argument to `Scenic.ViewPort.set_root/3`

## Motivation and Context

Better dev UX

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
