### PR TITLE
Add support for library themes

### DIFF
--- a/lib/scenic/component/button.ex
+++ b/lib/scenic/component/button.ex
@@ -131,7 +131,7 @@ defmodule Scenic.Component.Button do
 
   alias Scenic.Graph
   alias Scenic.Scene
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   alias Scenic.Assets.Static
 
   import Scenic.Primitives, only: [{:rrect, 3}, {:text, 3}, {:update_opts, 2}]
@@ -164,12 +164,12 @@ defmodule Scenic.Component.Button do
     # theme is passed in as an inherited style
     theme =
       case opts[:theme] do
-        nil -> Theme.preset(:primary)
-        :dark -> Theme.preset(:primary)
-        :light -> Theme.preset(:primary)
+        nil -> Themes.preset({:scenic, :primary})
+        {:scenic, :dark} -> Themes.preset({:scenic, :primary})
+        {:scenic, :light} -> Themes.preset({:scenic, :primary})
         theme -> theme
       end
-      |> Theme.normalize()
+      |> Themes.normalize()
 
     # font related info
     font = Keyword.get(styles, :font, @default_font)
@@ -278,11 +278,11 @@ defmodule Scenic.Component.Button do
     )
   end
 
-  defp do_special_theme_outline(graph, :dark, border) do
+  defp do_special_theme_outline(graph, {:scenic, :dark}, border) do
     Graph.modify(graph, :btn, &update_opts(&1, stroke: {1, border}))
   end
 
-  defp do_special_theme_outline(graph, :light, border) do
+  defp do_special_theme_outline(graph, {:scenic, :light}, border) do
     Graph.modify(graph, :btn, &update_opts(&1, stroke: {1, border}))
   end
 

--- a/lib/scenic/component/input/caret.ex
+++ b/lib/scenic/component/input/caret.ex
@@ -47,7 +47,7 @@ defmodule Scenic.Component.Input.Caret do
     ]
 
   alias Scenic.Graph
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
 
   @width 2
   @inset_v 4
@@ -86,7 +86,7 @@ defmodule Scenic.Component.Input.Caret do
       case opts[:color] do
         nil ->
           opts[:theme]
-          |> Theme.normalize()
+          |> Themes.normalize()
           |> Map.get(:highlight)
 
         c ->

--- a/lib/scenic/component/input/checkbox.ex
+++ b/lib/scenic/component/input/checkbox.ex
@@ -54,7 +54,7 @@ defmodule Scenic.Component.Input.Checkbox do
   alias Scenic.Graph
   alias Scenic.Scene
   alias Scenic.Primitive
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   alias Scenic.Script
   alias Scenic.Assets.Static
 
@@ -95,8 +95,8 @@ defmodule Scenic.Component.Input.Checkbox do
 
     # theme is passed in as an inherited style
     theme =
-      (opts[:theme] || Theme.preset(:dark))
-      |> Theme.normalize()
+      (opts[:theme] || Themes.preset({:scenic, :dark}))
+      |> Themes.normalize()
 
     # font related info
     {:ok, {Static.Font, fm}} = Static.meta(@default_font)

--- a/lib/scenic/component/input/dropdown.ex
+++ b/lib/scenic/component/input/dropdown.ex
@@ -84,7 +84,7 @@ defmodule Scenic.Component.Input.Dropdown do
 
   alias Scenic.Graph
   alias Scenic.Scene
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   import Scenic.Primitives
   alias Scenic.Assets.Static
 
@@ -188,8 +188,8 @@ defmodule Scenic.Component.Input.Dropdown do
 
     # theme is passed in as an inherited style
     theme =
-      (opts[:theme] || Theme.preset(:dark))
-      |> Theme.normalize()
+      (opts[:theme] || Themes.preset(:dark))
+      |> Themes.normalize()
 
     # font related info
     {:ok, {Static.Font, fm}} = Static.meta(@default_font)

--- a/lib/scenic/component/input/radio_button.ex
+++ b/lib/scenic/component/input/radio_button.ex
@@ -30,7 +30,7 @@ defmodule Scenic.Component.Input.RadioButton do
   alias Scenic.Scene
   alias Scenic.Graph
   alias Scenic.Primitive
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   alias Scenic.Assets.Static
 
   require Logger
@@ -70,8 +70,8 @@ defmodule Scenic.Component.Input.RadioButton do
   def init(scene, {text, id, checked?}, opts) do
     # theme is passed in as an inherited style
     theme =
-      (opts[:theme] || Theme.preset(:dark))
-      |> Theme.normalize()
+      (opts[:theme] || Themes.preset(:dark))
+      |> Themes.normalize()
 
     # font related info
     {:ok, {Static.Font, fm}} = Static.meta(@default_font)

--- a/lib/scenic/component/input/slider.ex
+++ b/lib/scenic/component/input/slider.ex
@@ -69,7 +69,7 @@ defmodule Scenic.Component.Input.Slider do
   use Scenic.Component, has_children: false
 
   alias Scenic.Graph
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   import Scenic.Primitives, only: [{:rect, 3}, {:line, 3}, {:rrect, 3}, {:update_opts, 2}]
 
   require Logger
@@ -192,8 +192,8 @@ defmodule Scenic.Component.Input.Slider do
 
     # theme is passed in as an inherited style
     theme =
-      (opts[:theme] || Theme.preset(:primary))
-      |> Theme.normalize()
+      (opts[:theme] || Themes.preset(:primary))
+      |> Themes.normalize()
 
     # get button specific styles
     width = opts[:width] || @default_width

--- a/lib/scenic/component/input/text_field.ex
+++ b/lib/scenic/component/input/text_field.ex
@@ -80,7 +80,7 @@ defmodule Scenic.Component.Input.TextField do
 
   alias Scenic.Graph
   alias Scenic.Component.Input.Caret
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   # alias Scenic.Assets.Static
 
   require Logger
@@ -138,8 +138,8 @@ defmodule Scenic.Component.Input.TextField do
 
     # theme is passed in as an inherited style
     theme =
-      (opts[:theme] || Theme.preset(:dark))
-      |> Theme.normalize()
+      (opts[:theme] || Themes.preset({:scenic, :dark}))
+      |> Themes.normalize()
 
     # get the text_field specific opts
     hint = opts[:hint] || @default_hint

--- a/lib/scenic/component/input/toggle.ex
+++ b/lib/scenic/component/input/toggle.ex
@@ -59,7 +59,7 @@ defmodule Scenic.Component.Input.Toggle do
   alias Scenic.Graph
   alias Scenic.Primitive
   alias Scenic.Primitive.Group
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   alias Scenic.ViewPort
 
   import Scenic.Primitives
@@ -131,7 +131,7 @@ defmodule Scenic.Component.Input.Toggle do
     # theme is passed in as an inherited style
     theme =
       opts[:theme]
-      |> Theme.normalize()
+      |> Themes.normalize()
 
     # get toggle specific opts
     thumb_radius = Keyword.get(opts, :thumb_radius, @default_thumb_radius)

--- a/lib/scenic/graph/compiler.ex
+++ b/lib/scenic/graph/compiler.ex
@@ -12,7 +12,7 @@ defmodule Scenic.Graph.Compiler do
   alias Scenic.Primitive
   alias Scenic.Graph
   alias Scenic.Color
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
   alias Scenic.Graph.Compiler
 
   # import IEx
@@ -271,7 +271,7 @@ defmodule Scenic.Graph.Compiler do
   defp do_text_color(ops, %{reqs: %{theme: theme}} = state) do
     color =
       theme
-      |> Theme.normalize()
+      |> Themes.normalize()
       |> Map.get(:text)
       |> Color.to_rgba()
 

--- a/lib/scenic/primitive/style/style.ex
+++ b/lib/scenic/primitive/style/style.ex
@@ -49,6 +49,7 @@ defmodule Scenic.Primitive.Style do
   """
 
   alias Scenic.Primitive.Style
+  alias Scenic.Themes
 
   # import IEx
 
@@ -85,7 +86,7 @@ defmodule Scenic.Primitive.Style do
     :stroke => Style.Stroke,
     :text_align => Style.TextAlign,
     :text_base => Style.TextBase,
-    :theme => Style.Theme
+    :theme => Themes
   }
 
   @valid_styles @opts_map
@@ -106,7 +107,7 @@ defmodule Scenic.Primitive.Style do
     stroke: [type: {:custom, Style.Stroke, :validate, []}],
     text_align: [type: {:custom, Style.TextAlign, :validate, []}],
     text_base: [type: {:custom, Style.TextBase, :validate, []}],
-    theme: [type: {:custom, Style.Theme, :validate, []}]
+    theme: [type: {:custom, Themes, :validate, []}]
   ]
 
   @callback validate(data :: any) :: {:ok, data :: any} | {:error, String.t()}

--- a/lib/scenic/primitive/style/theme.ex
+++ b/lib/scenic/primitive/style/theme.ex
@@ -1,187 +1,187 @@
-#
-#  Created by Boyd Multerer on 2018-08-18.
-#  Copyright © 2018 Kry10 Limited. All rights reserved.
-#
+# #
+# #  Created by Boyd Multerer on 2018-08-18.
+# #  Copyright © 2018 Kry10 Limited. All rights reserved.
+# #
 
-defmodule Scenic.Primitive.Style.Theme do
-  @moduledoc """
-  Themes are a way to bundle up a set of colors that are intended to be used
-  by components invoked by a scene.
+# defmodule Scenic.Primitive.Style.Theme do
+#   @moduledoc """
+#   Themes are a way to bundle up a set of colors that are intended to be used
+#   by components invoked by a scene.
 
-  There are a set of pre-defined themes.
-  You can also pass in a map of color values.
+#   There are a set of pre-defined themes.
+#   You can also pass in a map of color values.
 
-  Unlike other styles, The currently set theme is given to child components.
-  Each component gets to pick, choose, or ignore any colors in a given style.
+#   Unlike other styles, The currently set theme is given to child components.
+#   Each component gets to pick, choose, or ignore any colors in a given style.
 
-  ### Predefined Themes
-  * `:dark` - This is the default and most common. Use when the background is dark.
-  * `:light` - Use when the background is light colored.
+#   ### Predefined Themes
+#   * `:dark` - This is the default and most common. Use when the background is dark.
+#   * `:light` - Use when the background is light colored.
 
-  ### Specialty Themes
+#   ### Specialty Themes
 
-  The remaining themes are designed to color the standard components and don't really
-  make much sense when applied to the root of a graph. You could, but it would be...
-  interesting.
+#   The remaining themes are designed to color the standard components and don't really
+#   make much sense when applied to the root of a graph. You could, but it would be...
+#   interesting.
 
-  The most obvious place to use them is with [`Button`](Scenic.Component.Button.html)
-  components.
+#   The most obvious place to use them is with [`Button`](Scenic.Component.Button.html)
+#   components.
 
-  * `:primary` - Blue background. This is the primary button type indicator.
-  * `:secondary` - Grey background. Not primary type indicator.
-  * `:success` - Green background.
-  * `:danger` - Red background. Use for irreversible or dangerous actions.
-  * `:warning` - Orange background.
-  * `:info` - Lightish blue background.
-  * `:text` - Transparent background.
-  """
+#   * `:primary` - Blue background. This is the primary button type indicator.
+#   * `:secondary` - Grey background. Not primary type indicator.
+#   * `:success` - Green background.
+#   * `:danger` - Red background. Use for irreversible or dangerous actions.
+#   * `:warning` - Orange background.
+#   * `:info` - Lightish blue background.
+#   * `:text` - Transparent background.
+#   """
 
-  use Scenic.Primitive.Style
-  alias Scenic.Primitive.Style.Paint.Color
+#   use Scenic.Primitive.Style
+#   alias Scenic.Primitive.Style.Paint.Color
 
-  @theme_light %{
-    text: :black,
-    background: :white,
-    border: :dark_grey,
-    active: {215, 215, 215},
-    thumb: :cornflower_blue,
-    focus: :blue,
-    highlight: :saddle_brown
-  }
+#   @theme_light %{
+#     text: :black,
+#     background: :white,
+#     border: :dark_grey,
+#     active: {215, 215, 215},
+#     thumb: :cornflower_blue,
+#     focus: :blue,
+#     highlight: :saddle_brown
+#   }
 
-  @theme_dark %{
-    text: :white,
-    background: :black,
-    border: :light_grey,
-    active: {40, 40, 40},
-    thumb: :cornflower_blue,
-    focus: :cornflower_blue,
-    highlight: :sandy_brown
-  }
+#   @theme_dark %{
+#     text: :white,
+#     background: :black,
+#     border: :light_grey,
+#     active: {40, 40, 40},
+#     thumb: :cornflower_blue,
+#     focus: :cornflower_blue,
+#     highlight: :sandy_brown
+#   }
 
-  # specialty themes
-  @primary Map.merge(@theme_dark, %{background: {72, 122, 252}, active: {58, 94, 201}})
-  @secondary Map.merge(@theme_dark, %{background: {111, 117, 125}, active: {86, 90, 95}})
-  @success Map.merge(@theme_dark, %{background: {99, 163, 74}, active: {74, 123, 56}})
-  @danger Map.merge(@theme_dark, %{background: {191, 72, 71}, active: {164, 54, 51}})
-  @warning Map.merge(@theme_light, %{background: {239, 196, 42}, active: {197, 160, 31}})
-  @info Map.merge(@theme_dark, %{background: {94, 159, 183}, active: {70, 119, 138}})
-  @text Map.merge(@theme_dark, %{text: {72, 122, 252}, background: :clear, active: :clear})
+#   # specialty themes
+#   @primary Map.merge(@theme_dark, %{background: {72, 122, 252}, active: {58, 94, 201}})
+#   @secondary Map.merge(@theme_dark, %{background: {111, 117, 125}, active: {86, 90, 95}})
+#   @success Map.merge(@theme_dark, %{background: {99, 163, 74}, active: {74, 123, 56}})
+#   @danger Map.merge(@theme_dark, %{background: {191, 72, 71}, active: {164, 54, 51}})
+#   @warning Map.merge(@theme_light, %{background: {239, 196, 42}, active: {197, 160, 31}})
+#   @info Map.merge(@theme_dark, %{background: {94, 159, 183}, active: {70, 119, 138}})
+#   @text Map.merge(@theme_dark, %{text: {72, 122, 252}, background: :clear, active: :clear})
 
-  @themes %{
-    light: @theme_light,
-    dark: @theme_dark,
-    primary: @primary,
-    secondary: @secondary,
-    success: @success,
-    danger: @danger,
-    warning: @warning,
-    info: @info,
-    text: @text
-  }
+#   @themes %{
+#     light: @theme_light,
+#     dark: @theme_dark,
+#     primary: @primary,
+#     secondary: @secondary,
+#     success: @success,
+#     danger: @danger,
+#     warning: @warning,
+#     info: @info,
+#     text: @text
+#   }
 
-  # ============================================================================
-  # data verification and serialization
-  @doc false
-  def validate(theme)
-  def validate(:light), do: {:ok, :light}
-  def validate(:dark), do: {:ok, :dark}
-  def validate(:primary), do: {:ok, :primary}
-  def validate(:secondary), do: {:ok, :secondary}
-  def validate(:success), do: {:ok, :success}
-  def validate(:danger), do: {:ok, :danger}
-  def validate(:warning), do: {:ok, :warning}
-  def validate(:info), do: {:ok, :info}
-  def validate(:text), do: {:ok, :text}
+#   # ============================================================================
+#   # data verification and serialization
+#   @doc false
+#   def validate(theme)
+#   def validate(:light), do: {:ok, :light}
+#   def validate(:dark), do: {:ok, :dark}
+#   def validate(:primary), do: {:ok, :primary}
+#   def validate(:secondary), do: {:ok, :secondary}
+#   def validate(:success), do: {:ok, :success}
+#   def validate(:danger), do: {:ok, :danger}
+#   def validate(:warning), do: {:ok, :warning}
+#   def validate(:info), do: {:ok, :info}
+#   def validate(:text), do: {:ok, :text}
 
-  def validate(
-        %{
-          text: _,
-          background: _,
-          border: _,
-          active: _,
-          thumb: _,
-          focus: _
-        } = theme
-      ) do
-    # we know all the required colors are there.
-    # now make sure they are all valid colors, including any custom added ones.
-    theme
-    |> Enum.reduce({:ok, theme}, fn
-      _, {:error, msg} ->
-        {:error, msg}
+#   def validate(
+#         %{
+#           text: _,
+#           background: _,
+#           border: _,
+#           active: _,
+#           thumb: _,
+#           focus: _
+#         } = theme
+#       ) do
+#     # we know all the required colors are there.
+#     # now make sure they are all valid colors, including any custom added ones.
+#     theme
+#     |> Enum.reduce({:ok, theme}, fn
+#       _, {:error, msg} ->
+#         {:error, msg}
 
-      {key, color}, {:ok, _} = acc ->
-        case Color.validate(color) do
-          {:ok, _} -> acc
-          {:error, msg} -> err_color(key, msg)
-        end
-    end)
-  end
+#       {key, color}, {:ok, _} = acc ->
+#         case Color.validate(color) do
+#           {:ok, _} -> acc
+#           {:error, msg} -> err_color(key, msg)
+#         end
+#     end)
+#   end
 
-  def validate(name) when is_atom(name) do
-    {
-      :error,
-      """
-      #{IO.ANSI.red()}Invalid theme name
-      Received: #{inspect(name)}
-      #{IO.ANSI.yellow()}
-      Named themes must be from the following list:
-        :light, :dark, :primary, :secondary, :success, :danger, :warning, :info, :text#{IO.ANSI.default_color()}
-      """
-    }
-  end
+#   def validate(name) when is_atom(name) do
+#     {
+#       :error,
+#       """
+#       #{IO.ANSI.red()}Invalid theme name
+#       Received: #{inspect(name)}
+#       #{IO.ANSI.yellow()}
+#       Named themes must be from the following list:
+#         :light, :dark, :primary, :secondary, :success, :danger, :warning, :info, :text#{IO.ANSI.default_color()}
+#       """
+#     }
+#   end
 
-  def validate(%{} = map) do
-    {
-      :error,
-      """
-      #{IO.ANSI.red()}Invalid theme specification
-      Received: #{inspect(map)}
-      #{IO.ANSI.yellow()}
-      You passed in a map, but it didn't include all the required color specifications.
-      It must contain a valid color for each of the following entries.
-        :text, :background, :border, :active, :thumb, :focus
-      #{IO.ANSI.default_color()}
-      """
-    }
-  end
+#   def validate(%{} = map) do
+#     {
+#       :error,
+#       """
+#       #{IO.ANSI.red()}Invalid theme specification
+#       Received: #{inspect(map)}
+#       #{IO.ANSI.yellow()}
+#       You passed in a map, but it didn't include all the required color specifications.
+#       It must contain a valid color for each of the following entries.
+#         :text, :background, :border, :active, :thumb, :focus
+#       #{IO.ANSI.default_color()}
+#       """
+#     }
+#   end
 
-  def validate(data) do
-    {
-      :error,
-      """
-      #{IO.ANSI.red()}Invalid theme specification
-      Received: #{inspect(data)}
-      #{IO.ANSI.yellow()}
-      Themes can be a name from this list:
-        :light, :dark, :primary, :secondary, :success, :danger, :warning, :info, :text
+#   def validate(data) do
+#     {
+#       :error,
+#       """
+#       #{IO.ANSI.red()}Invalid theme specification
+#       Received: #{inspect(data)}
+#       #{IO.ANSI.yellow()}
+#       Themes can be a name from this list:
+#         :light, :dark, :primary, :secondary, :success, :danger, :warning, :info, :text
 
-      Or it may also be a map defining colors for the values of
-          :text, :background, :border, :active, :thumb, :focus
+#       Or it may also be a map defining colors for the values of
+#           :text, :background, :border, :active, :thumb, :focus
 
-      If you pass in a map, you may add your own colors in addition to the required ones.#{IO.ANSI.default_color()}
-      """
-    }
-  end
+#       If you pass in a map, you may add your own colors in addition to the required ones.#{IO.ANSI.default_color()}
+#       """
+#     }
+#   end
 
-  defp err_color(key, msg) do
-    {
-      :error,
-      """
-      #{IO.ANSI.red()}Invalid color in map
-      Map entry: #{inspect(key)}
-      #{msg}
-      """
-    }
-  end
+#   defp err_color(key, msg) do
+#     {
+#       :error,
+#       """
+#       #{IO.ANSI.red()}Invalid color in map
+#       Map entry: #{inspect(key)}
+#       #{msg}
+#       """
+#     }
+#   end
 
-  # --------------------------------------------------------
-  @doc false
-  def normalize(theme) when is_atom(theme), do: Map.get(@themes, theme)
-  def normalize(theme) when is_map(theme), do: theme
+#   # --------------------------------------------------------
+#   @doc false
+#   def normalize(theme) when is_atom(theme), do: Map.get(@themes, theme)
+#   def normalize(theme) when is_map(theme), do: theme
 
-  # --------------------------------------------------------
-  @doc false
-  def preset(theme), do: Map.get(@themes, theme)
-end
+#   # --------------------------------------------------------
+#   @doc false
+#   def preset(theme), do: Map.get(@themes, theme)
+# end

--- a/lib/scenic/scenes/error.ex
+++ b/lib/scenic/scenes/error.ex
@@ -66,7 +66,7 @@ defmodule Scenic.Scenes.Error do
 
     graph =
       Graph.build(font: @default_font, font_size: @size, translate: {@margin_h, @margin_v})
-      |> button("Try Again", id: :try_again, theme: :warning)
+      |> button("Try Again", id: :try_again, theme: {:scenic, :warning})
       |> text(head_msg, translate: {0, head_v}, font_size: @size + 4)
       |> text(args_msg, translate: {0, args_v}, fill: @args_color)
       |> text(err_msg, translate: {0, err_v}, fill: @error_color)

--- a/lib/scenic/themes.ex
+++ b/lib/scenic/themes.ex
@@ -1,4 +1,48 @@
 defmodule Scenic.Themes do
+  @moduledoc """
+  Manages theme libraries by registering your map of themes to a library key.
+  By registering themes in this way you can safely pull in themes from external libraries,
+  without theme names colliding, as well as get all the validation.
+
+  ### Required Configuration
+  Setting up themes requires some initial setup.
+
+  Example:
+
+   ```elixir
+  defmodule MyApplication.Themes do
+    @themes %{
+      light: @theme_light,
+      dark: @theme_dark,
+      primary: @primary,
+      secondary: @secondary,
+      success: @success,
+      danger: @danger,
+      warning: @warning,
+      info: @info,
+      text: @text
+    }
+
+    use Scenic.Themes,
+      sources: [
+        {:scenic, Scenic.Themes"},
+        {:my_app, load()}
+      ]
+
+    def load(), do: @themes
+  end
+  ```
+
+  After the Themes modules has been defined you need to configure it in your config file.any()
+
+  ```elixir
+  config :scenic, :themes,
+    module: MyApplication.Themes
+  ```
+
+  Now themes are passed around scenic in the form of `{:library_name, :theme_name}` as opposed to just :theme_name.
+  """
+
   @theme_light %{
     text: :black,
     background: :white,

--- a/lib/scenic/themes.ex
+++ b/lib/scenic/themes.ex
@@ -1,0 +1,193 @@
+defmodule Scenic.Themes do
+  @theme_light %{
+    text: :black,
+    background: :white,
+    border: :dark_grey,
+    active: {215, 215, 215},
+    thumb: :cornflower_blue,
+    focus: :blue,
+    highlight: :saddle_brown
+  }
+
+  @theme_dark %{
+    text: :white,
+    background: :black,
+    border: :light_grey,
+    active: {40, 40, 40},
+    thumb: :cornflower_blue,
+    focus: :cornflower_blue,
+    highlight: :sandy_brown
+  }
+
+  @primary Map.merge(@theme_dark, %{background: {72, 122, 252}, active: {58, 94, 201}})
+  @secondary Map.merge(@theme_dark, %{background: {111, 117, 125}, active: {86, 90, 95}})
+  @success Map.merge(@theme_dark, %{background: {99, 163, 74}, active: {74, 123, 56}})
+  @danger Map.merge(@theme_dark, %{background: {191, 72, 71}, active: {164, 54, 51}})
+  @warning Map.merge(@theme_light, %{background: {239, 196, 42}, active: {197, 160, 31}})
+  @info Map.merge(@theme_dark, %{background: {94, 159, 183}, active: {70, 119, 138}})
+  @text Map.merge(@theme_dark, %{text: {72, 122, 252}, background: :clear, active: :clear})
+  @themes %{
+    light: @theme_light,
+    dark: @theme_dark,
+    primary: @primary,
+    secondary: @secondary,
+    success: @success,
+    danger: @danger,
+    warning: @warning,
+    info: @info,
+    text: @text
+  }
+
+  @callback load() :: list
+
+  defmacro __using__(using_opts \\ []) do
+    quote do
+      alias Scenic.Primitive.Style.Paint.Color
+      @behaviour Scenic.Themes
+      @sources Keyword.get(unquote(using_opts), :sources, [])
+      @library_themes Enum.reduce(@sources, %{}, fn
+        {lib, module}, acc when is_atom(module) ->
+          themes = module.load()
+          Map.put_new(acc, lib, themes)
+        {lib, themes}, acc ->
+          Map.put_new(acc, lib, themes)
+        _, acc -> acc
+      end)
+
+      def validate(theme)
+      def validate({lib, theme} = lib_theme) when is_atom(theme) do
+        case normalize(lib_theme) do
+          map when is_map(map) ->
+            {:ok, lib_theme}
+          nil ->
+            {
+              :error,
+              """
+              #{IO.ANSI.red()}Invalid theme specification
+              Received: #{inspect(lib_theme)}
+              #{IO.ANSI.yellow()}
+              You passed in a tuple representing a library theme, but it could not be found.
+              Please ensure you've imported the the library correctly in your Themes module.
+              #{IO.ANSI.default_color()}
+              """
+            }
+        end
+      end
+
+      def validate(
+            %{
+              text: _,
+              background: _,
+              border: _,
+              active: _,
+              thumb: _,
+              focus: _
+            } = theme
+          ) do
+        # we know all the required colors are there.
+        # now make sure they are all valid colors, including any custom added ones.
+        theme
+        |> Enum.reduce({:ok, theme}, fn
+          _, {:error, msg} ->
+            {:error, msg}
+
+          {key, color}, {:ok, _} = acc ->
+            case Color.validate(color) do
+              {:ok, _} -> acc
+              {:error, msg} -> err_color(key, msg)
+            end
+        end)
+      end
+
+      def validate(%{} = map) do
+        {
+          :error,
+          """
+          #{IO.ANSI.red()}Invalid theme specification
+          Received: #{inspect(map)}
+          #{IO.ANSI.yellow()}
+          You passed in a map, but it didn't include all the required color specifications.
+          It must contain a valid color for each of the following entries.
+            :text, :background, :border, :active, :thumb, :focus
+          #{IO.ANSI.default_color()}
+          """
+        }
+      end
+
+      def validate(data) do
+        {
+          :error,
+          """
+          #{IO.ANSI.red()}Invalid theme specification
+          Received: #{inspect(data)}
+          #{IO.ANSI.yellow()}
+          Themes can be a tuple represent a theme for example:
+            {:scenic, :light}, {:scenic, :dark}
+
+          Or it may also be a map defining colors for the values of
+              :text, :background, :border, :active, :thumb, :focus
+
+          If you pass in a map, you may add your own colors in addition to the required ones.#{IO.ANSI.default_color()}
+          """
+        }
+      end
+
+      defp err_color(key, msg) do
+        {
+          :error,
+          """
+          #{IO.ANSI.red()}Invalid color in map
+          Map entry: #{inspect(key)}
+          #{msg}
+          """
+        }
+      end
+
+      @doc false
+      def normalize({lib, theme}) when is_atom(theme), do: Map.get(Map.get(@library_themes, lib), theme)
+      def normalize(theme) when is_map(theme), do: theme
+
+      @doc false
+      def preset({lib, theme}), do: Map.get(Map.get(@library_themes, lib), theme)
+    end
+  end
+
+  @moduledoc false
+  def module() do
+    with {:ok, config} <- Application.fetch_env(:scenic, :themes),
+         {:ok, module} <- Keyword.fetch(config, :module) do
+      module
+    else
+      _ ->
+        raise """
+        No Themes module is configured.
+        You need to create themes module in your application.
+        Then connect it to Scenic with some config.
+
+        Example Themes module that includes an optional alias:
+
+          defmodule MyApplication.Themes do
+            use Scenic.Assets.Static,
+              otp_app: :my_application,
+              alias: [
+                scenic: Scenic.Themes,
+              ]
+          end
+
+        Example configuration script (this goes in your config.exs file):
+
+          config :scenic, :themes,
+            module: MyApplication.Themes
+        """
+    end
+  end
+
+  def validate(theme), do: module().validate(theme)
+
+  def normalize(theme), do: module().normalize(theme)
+
+  def preset(theme), do: module().preset(theme)
+
+  @doc false
+  def load(), do: @themes
+end

--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -19,7 +19,7 @@ defmodule Scenic.ViewPort do
 
   # alias Scenic.Utilities
   alias Scenic.Utilities.Validators
-  alias Scenic.Primitive.Style.Theme
+  alias Scenic.Themes
 
   require Logger
 
@@ -118,7 +118,7 @@ defmodule Scenic.ViewPort do
       required: true,
       type: {:custom, Validators, :validate_scene, [:default_scene]}
     ],
-    theme: [type: {:custom, Theme, :validate, []}, default: :dark],
+    theme: [type: {:custom, Themes, :validate, []}, default: {:scenic, :dark}],
     drivers: [type: {:custom, Driver, :validate, []}, default: []],
     input_filter: [type: {:custom, __MODULE__, :validate_input_filter, []}, default: :all],
     opts: [
@@ -395,7 +395,7 @@ defmodule Scenic.ViewPort do
   def set_theme(viewport, theme)
 
   def set_theme(%ViewPort{pid: pid}, theme) do
-    case Theme.validate(theme) do
+    case Themes.validate(theme) do
       # {:ok, theme} -> GenServer.cast( pid, {:set_theme, theme} )
       {:ok, theme} -> GenServer.call(pid, {:set_theme, theme})
       err -> err
@@ -516,7 +516,7 @@ defmodule Scenic.ViewPort do
       # ets table for scripts. Public. Readable and Writable by others. The intended
       # use is that Scenes compile graphs in their own process and insert the scripts
       # in parallel to each other. (Trying to avoid serializing the VP on large messages)
-      # containing either script of graph data. The scripts can be read by multiple 
+      # containing either script of graph data. The scripts can be read by multiple
       # drivers at the same time, so is read parallel optimized. If the public write
       # becomes problematic, the next step is to have the scripts compile, then send
       # finished scripts to the VP for writing.
@@ -847,7 +847,7 @@ defmodule Scenic.ViewPort do
     # get the background from the theme
     background =
       theme
-      |> Theme.normalize()
+      |> Themes.normalize()
       |> Map.get(:background)
 
     send(pid, {@clear_color, background})
@@ -1171,7 +1171,7 @@ defmodule Scenic.ViewPort do
 
     background =
       theme
-      |> Theme.normalize()
+      |> Themes.normalize()
       |> Map.get(:background)
 
     case DynamicSupervisor.start_child(driver_sup, {Driver, {info, opts}}) do
@@ -1188,7 +1188,7 @@ defmodule Scenic.ViewPort do
     # get the background from the theme
     background =
       theme
-      |> Theme.normalize()
+      |> Themes.normalize()
       |> Map.get(:background)
 
     # tell the drivers the background changed
@@ -1641,7 +1641,7 @@ defmodule Scenic.ViewPort do
   # skip script primitives - no input handlers there
   defp comp_input_prim(input, _uid, %Primitive{module: Primitive.Script}, _, _tx), do: input
 
-  # it is a group. Calc the local transform if there one, but doesn't go into the 
+  # it is a group. Calc the local transform if there one, but doesn't go into the
   # list as a component itself...
   defp comp_input_prim(
          input,

--- a/test/scenic/graph/compile_test.exs
+++ b/test/scenic/graph/compile_test.exs
@@ -76,7 +76,7 @@ defmodule Scenic.Graph.CompilerTest do
   # ---------------------------------------------------------
   test "simple_theme graph works" do
     {:ok, list} =
-      Graph.build(font: :roboto, font_size: 26, theme: :dark)
+      Graph.build(font: :roboto, font_size: 26, theme: {:scenic, :dark})
       |> text("theme")
       |> Compiler.compile()
 
@@ -250,7 +250,7 @@ defmodule Scenic.Graph.CompilerTest do
   end
 
   # ---------------------------------------------------------
-  # Should correctly compile fill and stroke. Note that 
+  # Should correctly compile fill and stroke. Note that
   # primitives with neither fill nor stroke are eliminated completely
   test "fill and stroke are compiled correctly" do
     {:ok, list} =
@@ -380,7 +380,7 @@ defmodule Scenic.Graph.CompilerTest do
   # ---------------------------------------------------------
   test "font_styles graph works" do
     {:ok, list} =
-      Graph.build(theme: :dark)
+      Graph.build(theme: {:scenic, :dark})
       |> text("roboto", font: :roboto)
       |> text("size_64", font_size: 64)
       |> text("left", text_align: :left)

--- a/test/scenic/primitive/style/theme_test.exs
+++ b/test/scenic/primitive/style/theme_test.exs
@@ -3,66 +3,66 @@
 #  Copyright © 2018-2021 Kry10 Limited. All rights reserved.
 #
 
-defmodule Scenic.Primitive.Style.ThemeTest do
-  use ExUnit.Case, async: true
-  doctest Scenic.Primitive.Style.Theme
+# defmodule Scenic.Primitive.Style.ThemeTest do
+#   use ExUnit.Case, async: true
+#   doctest Scenic.Primitive.Style.Theme
 
-  alias Scenic.Primitive.Style.Theme
+#   alias Scenic.Primitive.Style.Theme
 
-  test "validate accepts the named themes" do
-    assert Theme.validate(:dark) == {:ok, :dark}
-    assert Theme.validate(:light) == {:ok, :light}
-    assert Theme.validate(:primary) == {:ok, :primary}
-    assert Theme.validate(:secondary) == {:ok, :secondary}
-    assert Theme.validate(:success) == {:ok, :success}
-    assert Theme.validate(:danger) == {:ok, :danger}
-    assert Theme.validate(:warning) == {:ok, :warning}
-    assert Theme.validate(:info) == {:ok, :info}
-    assert Theme.validate(:text) == {:ok, :text}
-  end
+#   test "validate accepts the named themes" do
+#     assert Theme.validate(:dark) == {:ok, :dark}
+#     assert Theme.validate(:light) == {:ok, :light}
+#     assert Theme.validate(:primary) == {:ok, :primary}
+#     assert Theme.validate(:secondary) == {:ok, :secondary}
+#     assert Theme.validate(:success) == {:ok, :success}
+#     assert Theme.validate(:danger) == {:ok, :danger}
+#     assert Theme.validate(:warning) == {:ok, :warning}
+#     assert Theme.validate(:info) == {:ok, :info}
+#     assert Theme.validate(:text) == {:ok, :text}
+#   end
 
-  test "validate rejects invalid theme names" do
-    {:error, msg} = Theme.validate(:invalid)
-    assert msg =~ "Named themes must be from the following list"
-  end
+#   test "validate rejects invalid theme names" do
+#     {:error, msg} = Theme.validate(:invalid)
+#     assert msg =~ "Named themes must be from the following list"
+#   end
 
-  test "validate accepts maps of colors" do
-    color_map = %{
-      text: :red,
-      background: :green,
-      border: :blue,
-      active: :magenta,
-      thumb: :cyan,
-      focus: :yellow,
-      my_color: :black
-    }
+#   test "validate accepts maps of colors" do
+#     color_map = %{
+#       text: :red,
+#       background: :green,
+#       border: :blue,
+#       active: :magenta,
+#       thumb: :cyan,
+#       focus: :yellow,
+#       my_color: :black
+#     }
 
-    assert Theme.validate(color_map) == {:ok, color_map}
-  end
+#     assert Theme.validate(color_map) == {:ok, color_map}
+#   end
 
-  test "validate rejects maps with invalid colors" do
-    color_map = %{
-      text: :red,
-      background: :green,
-      border: :invalid,
-      active: :magenta,
-      thumb: :cyan,
-      focus: :yellow,
-      my_color: :black
-    }
+#   test "validate rejects maps with invalid colors" do
+#     color_map = %{
+#       text: :red,
+#       background: :green,
+#       border: :invalid,
+#       active: :magenta,
+#       thumb: :cyan,
+#       focus: :yellow,
+#       my_color: :black
+#     }
 
-    {:error, msg} = Theme.validate(color_map)
-    assert msg =~ "Map entry: :border"
-    assert msg =~ "Invalid Color specification: :invalid"
-  end
+#     {:error, msg} = Theme.validate(color_map)
+#     assert msg =~ "Map entry: :border"
+#     assert msg =~ "Invalid Color specification: :invalid"
+#   end
 
-  test "verify rejects maps without the standard colors" do
-    color_map = %{some_name: :red}
-    {:error, msg} = Theme.validate(color_map)
-    assert msg =~ "didn't include all the required color"
-  end
+#   test "verify rejects maps without the standard colors" do
+#     color_map = %{some_name: :red}
+#     {:error, msg} = Theme.validate(color_map)
+#     assert msg =~ "didn't include all the required color"
+#   end
 
-  test "verify rejects  invalid values" do
-    {:error, _msg} = Theme.validate("totally wrong")
-  end
-end
+#   test "verify rejects  invalid values" do
+#     {:error, _msg} = Theme.validate("totally wrong")
+#   end
+# end

--- a/test/scenic/scene_test.exs
+++ b/test/scenic/scene_test.exs
@@ -134,7 +134,7 @@ defmodule Scenic.SceneTest do
     %ViewPort{} = vp
     assert is_pid(pid)
     assert module == TestSceneNoKids
-    assert theme == :dark
+    assert theme == {:scenic, :dark}
     assert is_pid(parent)
     assert children == nil
     assert child_supervisor == nil
@@ -167,7 +167,7 @@ defmodule Scenic.SceneTest do
     %ViewPort{} = vp
     assert is_pid(pid)
     assert module == TestSceneKids
-    assert theme == :dark
+    assert theme == {:scenic, :dark}
     assert is_pid(parent)
     %{} = children
     assert is_pid(child_supervisor)

--- a/test/scenic/themes_test.exs
+++ b/test/scenic/themes_test.exs
@@ -1,0 +1,122 @@
+defmodule Scenic.ThemesTest do
+  use ExUnit.Case, async: true
+  doctest Scenic.Themes
+
+  alias Scenic.Themes
+
+  # we expect errors to be logged in this set of tests. This happens when we purposefully
+  # attempted to load an asset that has been tampered with. So turn off the logging to
+  # keep the tests clean.
+  @moduletag :capture_log
+
+  @theme_light %{
+    text: :black,
+    background: :white,
+    border: :dark_grey,
+    active: {215, 215, 215},
+    thumb: :cornflower_blue,
+    focus: :blue,
+    highlight: :saddle_brown
+  }
+
+  @theme_dark %{
+    text: :white,
+    background: :black,
+    border: :light_grey,
+    active: {40, 40, 40},
+    thumb: :cornflower_blue,
+    focus: :cornflower_blue,
+    highlight: :sandy_brown
+  }
+
+  @primary Map.merge(@theme_dark, %{background: {72, 122, 252}, active: {58, 94, 201}})
+  @secondary Map.merge(@theme_dark, %{background: {111, 117, 125}, active: {86, 90, 95}})
+  @success Map.merge(@theme_dark, %{background: {99, 163, 74}, active: {74, 123, 56}})
+  @danger Map.merge(@theme_dark, %{background: {191, 72, 71}, active: {164, 54, 51}})
+  @warning Map.merge(@theme_light, %{background: {239, 196, 42}, active: {197, 160, 31}})
+  @info Map.merge(@theme_dark, %{background: {94, 159, 183}, active: {70, 119, 138}})
+  @text Map.merge(@theme_dark, %{text: {72, 122, 252}, background: :clear, active: :clear})
+
+  @themes %{
+    light: @theme_light,
+    dark: @theme_dark,
+    primary: @primary,
+    secondary: @secondary,
+    success: @success,
+    danger: @danger,
+    warning: @warning,
+    info: @info,
+    text: @text
+  }
+
+  # import IEx
+
+  test "module returns the configured library module" do
+    assert Themes.module() == Scenic.Test.Themes
+  end
+
+  test "load returns the themes" do
+    assert Themes.load() == @themes
+  end
+
+  test "normalize returns the correct theme" do
+    assert Themes.normalize({:scenic, :dark}) == @theme_dark
+  end
+
+  test "validate accepts the named themes" do
+    assert Themes.validate({:scenic, :dark}) == {:ok, {:scenic, :dark}}
+    assert Themes.validate({:scenic, :light}) == {:ok, {:scenic, :light}}
+    assert Themes.validate({:scenic, :primary}) == {:ok, {:scenic, :primary}}
+    assert Themes.validate({:scenic, :secondary}) == {:ok, {:scenic, :secondary}}
+    assert Themes.validate({:scenic, :success}) == {:ok, {:scenic, :success}}
+    assert Themes.validate({:scenic, :danger}) == {:ok, {:scenic, :danger}}
+    assert Themes.validate({:scenic, :warning}) == {:ok, {:scenic, :warning}}
+    assert Themes.validate({:scenic, :info}) == {:ok, {:scenic, :info}}
+    assert Themes.validate({:scenic, :text}) == {:ok, {:scenic, :text}}
+  end
+
+  test "validate rejects invalid theme names" do
+    {:error, msg} = Themes.validate(:invalid)
+    assert msg =~ "Themes can be a tuple represent a theme for example:"
+  end
+
+  test "validate accepts maps of colors" do
+    color_map = %{
+      text: :red,
+      background: :green,
+      border: :blue,
+      active: :magenta,
+      thumb: :cyan,
+      focus: :yellow,
+      my_color: :black
+    }
+
+    assert Themes.validate(color_map) == {:ok, color_map}
+  end
+
+  test "validate rejects maps with invalid colors" do
+    color_map = %{
+      text: :red,
+      background: :green,
+      border: :invalid,
+      active: :magenta,
+      thumb: :cyan,
+      focus: :yellow,
+      my_color: :black
+    }
+
+    {:error, msg} = Themes.validate(color_map)
+    assert msg =~ "Map entry: :border"
+    assert msg =~ "Invalid Color specification: :invalid"
+  end
+
+  test "verify rejects maps without the standard colors" do
+    color_map = %{some_name: :red}
+    {:error, msg} = Themes.validate(color_map)
+    assert msg =~ "didn't include all the required color"
+  end
+
+  test "verify rejects invalid values" do
+    {:error, _msg} = Themes.validate("totally wrong")
+  end
+end

--- a/test/scenic/view_port_test.exs
+++ b/test/scenic/view_port_test.exs
@@ -266,7 +266,7 @@ defmodule Scenic.ViewPortTest do
 
   # set the theme - this should restart the current scene
   test "set_theme works", %{vp: vp} do
-    assert ViewPort.set_theme(vp, :dark) == :ok
+    assert ViewPort.set_theme(vp, {:scenic, :dark}) == :ok
   end
 
   # ---------------------------------------------------------------------------

--- a/test/support/themes.ex
+++ b/test/support/themes.ex
@@ -1,0 +1,6 @@
+defmodule Scenic.Test.Themes do
+  use Scenic.Themes,
+    sources: [
+      {:scenic, Scenic.Themes}
+    ]
+end

--- a/test/support/view_port.ex
+++ b/test/support/view_port.ex
@@ -26,7 +26,7 @@ defmodule Scenic.Test.ViewPort do
       )
 
     scene_state = %{
-      theme: :dark,
+      theme: {:scenic, :dark},
       has_children: true,
       name: nil,
       module: __MODULE__,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
 # dynamically update the config to point to the test assets
 Application.put_env(:scenic, :assets, module: Scenic.Test.Assets)
 
+Application.put_env(:scenic, :themes, module: Scenic.Test.Themes)
+
 ExUnit.start()


### PR DESCRIPTION
## Description

The pull request adds support for registering library themes, similar to static assets. 

Themes are now registered and validated within scenic from `Scenic.Themes`.

## Motivation and Context

Before the theme module was on `Scenic.Primitive.Style.Theme`, which felt like it would only be used in the context of primitives/components. However, is was imported everywhere that theme validation was needed, and had all the themes directly on that module. This means Scenic would not be able to validate custom themes that were not a map.

Also, there were times when scenic would pass around `:dark`, `:light` atoms, you had to know this ahead of time and know to validate or get the preset via `Scenic.Primitive.Style.Theme`. With all themes now registered through a single module, you can now fetch presets and validate any theme from `Scenic.Themes`.

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ x] New feature (a non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)
