### PR TITLE
Update to support NimbleOptions 0.4

### DIFF
--- a/lib/scenic/primitive.ex
+++ b/lib/scenic/primitive.ex
@@ -228,11 +228,22 @@ defmodule Scenic.Primitive do
 
     tx =
       case NimbleOptions.validate(tx, Transform.opts_schema()) do
-        {:ok, tx} -> tx
+        {:ok, tx} -> apply_opts_shortcuts(tx)
         {:error, error} -> raise Exception.message(error)
       end
 
     {:ok, id, st, tx, op}
+  end
+
+  # Work around NimbleOptions rename_to deprecation
+  # https://github.com/dashbitco/nimble_options/issues/78
+  defp apply_opts_shortcuts(opts) do
+    Enum.map(opts, fn
+      {:t, val} -> {:translate, val}
+      {:s, val} -> {:scale, val}
+      {:r, val} -> {:rotate, val}
+      {key, val} -> {key, val}
+    end)
   end
 
   # ============================================================================

--- a/lib/scenic/primitive/transform/transform.ex
+++ b/lib/scenic/primitive/transform/transform.ex
@@ -56,13 +56,12 @@ defmodule Scenic.Primitive.Transform do
   }
 
   @opts_schema [
-    # Note: Due to https://github.com/dashbitco/nimble_options/issues/68 any
-    # `:rename_to` entries need to come before the keys that they are renaming
-    t: [rename_to: :translate],
-    s: [rename_to: :scale],
-    r: [rename_to: :rotate],
+    # Note: the shortcut versions are translated to the full versions in Scenic.Primitive
+    t: [type: {:custom, Transform.Translate, :validate, []}],
     translate: [type: {:custom, Transform.Translate, :validate, []}],
+    s: [type: {:custom, Transform.Scale, :validate, []}],
     scale: [type: {:custom, Transform.Scale, :validate, []}],
+    r: [type: {:custom, Transform.Rotate, :validate, []}],
     rotate: [type: {:custom, Transform.Rotate, :validate, []}],
     pin: [type: {:custom, Transform.Pin, :validate, []}],
     matrix: [type: {:custom, Transform.Matrix, :validate, []}]

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Scenic.Mixfile do
   defp deps do
     [
       {:font_metrics, "~> 0.5.0"},
-      {:nimble_options, "~> 0.3.4"},
+      {:nimble_options, "~> 0.3.4 or ~> 0.4.0"},
       {:ex_image_info, "~> 0.2.4"},
       {:truetype_metrics, "~> 0.5"},
 

--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "msgpax": {:hex, :msgpax, "2.2.4", "7b3790ef684089076b63c0f08c2f4b079c6311daeb006b69e4ed2bf67518291e", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: true]}], "hexpm", "b351b6d992d79624a8430a99d21a41b36b1b90edf84326a294e9f4a2de11f089"},
-  "nimble_options": {:hex, :nimble_options, "0.3.7", "1e52dd7673d36138b1a5dede183b5d86dff175dc46d104a8e98e396b85b04670", [:mix], [], "hexpm", "2086907e6665c6b6579be54ef5001928df5231f355f71ed258f80a55e9f63633"},
+  "nimble_options": {:hex, :nimble_options, "0.4.0", "c89babbab52221a24b8d1ff9e7d838be70f0d871be823165c94dd3418eea728f", [:mix], [], "hexpm", "e6701c1af326a11eea9634a3b1c62b475339ace9456c1a23ec3bc9a847bca02d"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/scenic/primitive/transform_test.exs
+++ b/test/scenic/primitive/transform_test.exs
@@ -45,7 +45,7 @@ defmodule Scenic.Primitive.TransformTest do
     tx = [s: 0.6]
 
     assert NimbleOptions.validate(tx, Transform.opts_schema()) ==
-             {:ok, [s: 0.6, scale: {0.6, 0.6}]}
+             {:ok, [s: {0.6, 0.6}]}
   end
 
   test "combine calculates the local matrix in the right order" do

--- a/test/scenic/primitive_test.exs
+++ b/test/scenic/primitive_test.exs
@@ -177,6 +177,21 @@ defmodule Scenic.PrimitiveTest do
            }
   end
 
+  test "merge_opts supports t translate shortcut" do
+    assert Primitive.merge_opts(@primitive, t: {10, 42}).transforms ==
+             Primitive.merge_opts(@primitive, translate: {10, 42}).transforms
+  end
+
+  test "merge_opts supports s scale shortcut" do
+    assert Primitive.merge_opts(@primitive, s: 1.2).transforms ==
+             Primitive.merge_opts(@primitive, scale: 1.2).transforms
+  end
+
+  test "merge_opts supports r rotate shortcut" do
+    assert Primitive.merge_opts(@primitive, r: 1.4).transforms ==
+             Primitive.merge_opts(@primitive, rotate: 1.4).transforms
+  end
+
   test "merge_opts rejects invalid style" do
     assert_raise RuntimeError, fn ->
       Primitive.merge_opts(@primitive, fill: :invalid)


### PR DESCRIPTION
## Description

Work around deprecation of `:rename_to` by post processing the options to provide the shortcut functionality. I also opened a feature request on NimbleOptions to support this without post-processing: https://github.com/dashbitco/nimble_options/issues/78

## Motivation and Context

Other projects are already requiring NimbleOptions 0.4 (e.g. [Finch 0.10.1](https://hex.pm/packages/finch/0.10.1)) so to upgrade my project I need to upgrade Scenic's NimbleOptions version. And I want to avoid a bunch of runtime deprecation notices of `rename_to` which I've handled in this PR.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
