### PR TITLE
Scenic.Assets.Stream.Bitmap.put_offset/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.0
+* Add the Scenic.Assets.Stream.Bitmap.put_offset/3 api
+* Various cleanup and documentation fixes
+* This is a __MAJOR__ update. As Connor Rigby put it in a call... "What hasn't changed?"
+* See the v.11 upgrade guide for an overview.
+
 ## 0.11.0-beta.0
 * This is a __MAJOR__ update. As Connor Rigby put it in a call... "What hasn't changed?"
 * See the v.11 upgrade guide for an overview.

--- a/lib/scenic/assets/stream/bitmap.ex
+++ b/lib/scenic/assets/stream/bitmap.ex
@@ -284,28 +284,28 @@ defmodule Scenic.Assets.Stream.Bitmap do
   def put_offset(mutable, offset, color)
 
   def put_offset({@mutable, {w, h, :g}, p}, offset, color) when is_integer(offset) do
-    if offset > w * h, do: raise "Offset is out of bounds"
+    if offset > w * h, do: raise("Offset is out of bounds")
     {:color_g, g} = Color.to_g(color)
     nif_put(p, offset, g)
     {@mutable, {w, h, :g}, p}
   end
 
   def put_offset({@mutable, {w, h, :ga}, p}, offset, color) when is_integer(offset) do
-    if offset > w * h, do: raise "Offset is out of bounds"
+    if offset > w * h, do: raise("Offset is out of bounds")
     {:color_ga, {g, a}} = Color.to_ga(color)
     nif_put(p, offset, g, a)
     {@mutable, {w, h, :ga}, p}
   end
 
   def put_offset({@mutable, {w, h, :rgb}, p}, offset, color) when is_integer(offset) do
-    if offset > w * h, do: raise "Offset is out of bounds"
+    if offset > w * h, do: raise("Offset is out of bounds")
     {:color_rgb, {r, g, b}} = Color.to_rgb(color)
     nif_put(p, offset, r, g, b)
     {@mutable, {w, h, :rgb}, p}
   end
 
   def put_offset({@mutable, {w, h, :rgba}, p}, offset, color) when is_integer(offset) do
-    if offset > w * h, do: raise "Offset is out of bounds"
+    if offset > w * h, do: raise("Offset is out of bounds")
     {:color_rgba, {r, g, b, a}} = Color.to_rgba(color)
     nif_put(p, offset, r, g, b, a)
     {@mutable, {w, h, :rgba}, p}

--- a/lib/scenic/assets/stream/bitmap.ex
+++ b/lib/scenic/assets/stream/bitmap.ex
@@ -265,6 +265,52 @@ defmodule Scenic.Assets.Stream.Bitmap do
     {@mutable, {w, h, :rgba}, p}
   end
 
+  # --------------------------------------------------------
+  @doc """
+  Set the color value of a single pixel in a bitmap using an offset from the start.
+
+  Only works with mutable bitmaps.
+
+  The color you provide can be any valid value from the `Scenic.Color` module.
+
+  Unlike the `put` function, which specifies the pixel by `x` and `y` position,
+  `put_offset` takes an offset directly into the data.
+
+  The offset would be the same as y * width + x.
+  """
+
+  @spec put_offset(mutable :: m(), offset :: pos_integer, color :: Color.t()) ::
+          mutable :: m()
+  def put_offset(mutable, offset, color)
+
+  def put_offset({@mutable, {w, h, :g}, p}, offset, color) when is_integer(offset) do
+    if offset > w * h, do: raise "Offset is out of bounds"
+    {:color_g, g} = Color.to_g(color)
+    nif_put(p, offset, g)
+    {@mutable, {w, h, :g}, p}
+  end
+
+  def put_offset({@mutable, {w, h, :ga}, p}, offset, color) when is_integer(offset) do
+    if offset > w * h, do: raise "Offset is out of bounds"
+    {:color_ga, {g, a}} = Color.to_ga(color)
+    nif_put(p, offset, g, a)
+    {@mutable, {w, h, :ga}, p}
+  end
+
+  def put_offset({@mutable, {w, h, :rgb}, p}, offset, color) when is_integer(offset) do
+    if offset > w * h, do: raise "Offset is out of bounds"
+    {:color_rgb, {r, g, b}} = Color.to_rgb(color)
+    nif_put(p, offset, r, g, b)
+    {@mutable, {w, h, :rgb}, p}
+  end
+
+  def put_offset({@mutable, {w, h, :rgba}, p}, offset, color) when is_integer(offset) do
+    if offset > w * h, do: raise "Offset is out of bounds"
+    {:color_rgba, {r, g, b, a}} = Color.to_rgba(color)
+    nif_put(p, offset, r, g, b, a)
+    {@mutable, {w, h, :rgba}, p}
+  end
+
   defp nif_put(_, _, _), do: :erlang.nif_error("Did not find nif_put_g")
   defp nif_put(_, _, _, _), do: :erlang.nif_error("Did not find nif_put_ga")
   defp nif_put(_, _, _, _, _), do: :erlang.nif_error("Did not find nif_put_rgb")

--- a/test/scenic/assets/stream/bitmap_test.exs
+++ b/test/scenic/assets/stream/bitmap_test.exs
@@ -182,6 +182,43 @@ defmodule Scenic.Assets.Stream.BitmapTest do
   end
 
   # --------------------------------------------------------
+  test "put_offset :g works" do
+    color = Color.to_g(5)
+
+    mut = Bitmap.build(:g, @width, @height)
+    assert Bitmap.get(mut, 2, 2) == {:color_g, 0}
+    mut = Bitmap.put_offset(mut, @width * 2 + 2, color)
+    assert Bitmap.get(mut, 2, 2) == color
+  end
+
+  test "put_offset :ga works" do
+    color = Color.to_ga({5, 100})
+
+    mut = Bitmap.build(:ga, @width, @height)
+    assert Bitmap.get(mut, 2, 2) == {:color_ga, {0, 0}}
+    mut = Bitmap.put_offset(mut, @width * 2 + 2, color)
+    assert Bitmap.get(mut, 2, 2) == color
+  end
+
+  test "put_offset :rgb works" do
+    color = Color.to_rgb({1, 2, 3})
+
+    mut = Bitmap.build(:rgb, @width, @height)
+    assert Bitmap.get(mut, 2, 2) == {:color_rgb, {0, 0, 0}}
+    mut = Bitmap.put_offset(mut, @width * 2 + 2, color)
+    assert Bitmap.get(mut, 2, 2) == color
+  end
+
+  test "put_offset :rgba works" do
+    color = Color.to_rgba({1, 2, 3, 100})
+
+    mut = Bitmap.build(:rgba, @width, @height)
+    assert Bitmap.get(mut, 2, 2) == {:color_rgba, {0, 0, 0, 0}}
+    mut = Bitmap.put_offset(mut, @width * 2 + 2, color)
+    assert Bitmap.get(mut, 2, 2) == color
+  end
+
+  # --------------------------------------------------------
   test "clear :g works" do
     color = Color.to_g(5)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

This PR adds the function Scenic.Assets.Stream.Bitmap.put_offset/3, which can be used to poke a color into a mutable, stream-able bitmap by pure offset from the beginning of the pixel array. This is useful for certain calculated bitmap rendering.

## Motivation and Context

There are some algorithms that want to poke color values into the array of pixels by offset from the beginning of the array instead of by `{x, y}` position. Recently ran into this when attempting to decode `*.png` and `*.ico` files purely in elixir.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
