### PR TITLE
Fix Scenic.ViewPort.info/1 typespec

### DIFF
--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -236,7 +236,7 @@ defmodule Scenic.ViewPort do
   @doc """
   Retrieve a %ViewPort{} struct given just the viewport's pid
   """
-  @spec info(pid :: ViewPort.t() | GenServer.server()) :: map
+  @spec info(pid :: ViewPort.t() | GenServer.server()) :: {:ok, map}
   def info(%ViewPort{pid: pid}), do: info(pid)
 
   def info(pid) when is_pid(pid) or is_atom(pid) do


### PR DESCRIPTION
## Description

`Scenic.ViewPort.info/1` returns an ok-tuple, so the typespec should be updated to match

```
iex(3)> {:ok, viewport} = Scenic.ViewPort.info(pid("0.291.0"))
{:ok,
 %Scenic.ViewPort{
   name: :main_viewport,
   pid: #PID<0.291.0>,
   script_table: #Reference<0.433853922.3194355713.213985>,
   size: {800, 600}
 }}
```

## Motivation and Context

Without a correct typespec an incorrect dialyzer error is created

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
