### PR TITLE
Dynamic viewport example

### DIFF
--- a/lib/scenic/driver.ex
+++ b/lib/scenic/driver.ex
@@ -887,7 +887,11 @@ defmodule Scenic.Driver do
     name: [type: :atom]
   ]
 
-  @doc false
+  @doc """
+  Validate driver configuration
+
+  Used primarily for dynamic view port creation
+  """
   def validate([]), do: {:ok, []}
 
   def validate(drivers) do

--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -100,7 +100,6 @@ defmodule Scenic.ViewPort do
       {:ok, view_port} = Scenic.ViewPort.info(:main_viewport)
 
       opts = [
-        name: name,
         module: Scenic.Driver.Local,
         window: [resizeable: false, title: "My Example Scenic App"],
         on_close: :stop_system

--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -91,6 +91,20 @@ defmodule Scenic.ViewPort do
   leave the scene that thinks it has "captured" the input in an inconsistent
   state, so this is not recommended.
 
+  ## Dynamically Creating View Ports
+
+  Pass in the same set of opts that you would use when starting `Scenic` in your
+  supervision tree. For example:
+
+      opts = [
+        name: name,
+        module: Scenic.Driver.Local,
+        window: [resizeable: false, title: "My Example Scenic App"],
+        on_close: :stop_system
+      ]
+
+      {:ok, [opts]} = Scenic.Driver.validate([opts])
+      Scenic.ViewPort.start_driver(view_port, opts)
   """
 
   @type t :: %ViewPort{

--- a/lib/scenic/view_port.ex
+++ b/lib/scenic/view_port.ex
@@ -96,6 +96,9 @@ defmodule Scenic.ViewPort do
   Pass in the same set of opts that you would use when starting `Scenic` in your
   supervision tree. For example:
 
+      # Assuming you use the default view port name from the generator
+      {:ok, view_port} = Scenic.ViewPort.info(:main_viewport)
+
       opts = [
         name: name,
         module: Scenic.Driver.Local,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

Adds a dynamic view port example and allows creating the view port dynamically with the least amount of code changes. A different API may be desired, I didn't think too hard about this particular implementation. I thought about adding the example to the guides but since the guides are currently empty, putting it directly in the view port docs seemed to make the most sense.

Previously the `Scenic.Driver.validate/1` function was considered private (because it used `@doc false`)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
