### PR TITLE
Fix divide by zero in Scenic.Color

### DIFF
--- a/lib/scenic/color.ex
+++ b/lib/scenic/color.ex
@@ -535,7 +535,7 @@ defmodule Scenic.Color do
 
     s =
       case delta do
-        0 -> 0
+        0.0 -> 0.0
         d -> d / (1 - abs(2 * l - 1))
       end
 

--- a/lib/scenic/color.ex
+++ b/lib/scenic/color.ex
@@ -224,6 +224,10 @@ defmodule Scenic.Color do
   @hsv :color_hsv
   @hsl :color_hsl
 
+  # Epsilon value from JS
+  # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON
+  @epsilon 2.22044e-16
+
   @type implicit ::
           atom
           | {name :: atom, a :: integer}
@@ -534,9 +538,9 @@ defmodule Scenic.Color do
     l = (max + min) / 2
 
     s =
-      case delta do
-        0.0 -> 0.0
-        d -> d / (1 - abs(2 * l - 1))
+      cond do
+        delta < @epsilon -> 0.0
+        true -> delta / (1 - abs(2 * l - 1))
       end
 
     {h, s * 100, l * 100}

--- a/test/scenic/color_test.exs
+++ b/test/scenic/color_test.exs
@@ -175,6 +175,12 @@ defmodule Scenic.ColorTest do
     assert Color.to_hsl({:color_hsl, {1.1, 1.2, 1.3}}) == {:color_hsl, {1.1, 1.2, 1.3}}
   end
 
+  test "white hsl to hsv to rgb" do
+    assert Color.to_hsv(:white)
+           |> Color.to_hsl()
+           |> Color.to_rgb() == {:color_rgb, {255, 255, 255}}
+  end
+
   test "named looks right" do
     Color.named()
     |> Enum.each(fn {n, {r, g, b}} ->


### PR DESCRIPTION
## Description

Fix divide by zero in `Scenic.Color` which prevented some color calculations

## Motivation and Context

Fixes a bug

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
