### PR TITLE
Fix error in the bounds/1 documentation

### DIFF
--- a/lib/scenic/graph.ex
+++ b/lib/scenic/graph.ex
@@ -846,7 +846,7 @@ defmodule Scenic.Graph do
   @doc """
   Compute the bounding box that contains the graph.
 
-  Returns `{left, right, top, bottom}` or `nil` if the graph is empty.
+  Returns `{left, top, right, bottom}` or `nil` if the graph is empty.
   """
   @spec bounds(graph :: t()) :: Scenic.Graph.bounds() | nil
   defdelegate bounds(graph), to: Scenic.Graph.Bounds, as: :compute


### PR DESCRIPTION
## Description

There's an error in the documentation for bounds/1, the docs say the format is `{left, right, top, bottom}`, but that's not correct, it's actually `{left, top, right, bottom}`

It's a tiny error but pretty misleading for anyone trying to use this function, hahaha!

Just to prove this completely, I made a test app & created this graph:

```
init_graph =
      Graph.build()
      |> Scenic.Primitives.rectangle({100, 200}, t: {25, 75}, fill: :red)
```

which renders like this:

![image](https://user-images.githubusercontent.com/1879634/184435657-8fc696fd-5f63-4e77-bb82-f10fafe6c8cb.png)

In the handle_event/3 I checked the bounds:

```
  def handle_input(event, _context, state) do
    Logger.info("Received event: #{inspect(event)}")
    bounds = Scenic.Graph.bounds(state.assigns.graph)
    IO.inspect bounds, label: "Bounds"
    {:noreply, state}
  end
```

I see: `Bounds: {25.0, 75.0, 125.0, 275.0}`

Also the typespec in Scenic.Graph shows the order `left, top, right, bottom` so I'm pretty certain now it was just a documentation error https://github.com/boydm/scenic/blob/master/lib/scenic/graph.ex#L175

## Motivation and Context

When using bounds/1 I was getting some very strange behaviour due to how it was documented vs how it works.

## Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)