### PR TITLE
Fix syntax error in v0.11 migration guide

### DIFF
--- a/guides/upgrading_to_v0.11.md
+++ b/guides/upgrading_to_v0.11.md
@@ -208,7 +208,7 @@ defmodule MyDevice.Scene.Example do
 
   # display any received events
   def handle_event(event, _, %{assigns: %{graph: graph}} = scene) do
-    graph = Graph.modify( graph, :text, &text(&1, inspect(event))
+    graph = Graph.modify( graph, :text, &text(&1, inspect(event)))
 
     scene =
       scene


### PR DESCRIPTION
The example provided in "Upgrade Steps" is missing a close paren.